### PR TITLE
[Feat] 모든 편지 수 조회, 메인 홈 위치 오류 수정 등

### DIFF
--- a/src/api/image/image.tsx
+++ b/src/api/image/image.tsx
@@ -1,0 +1,12 @@
+import { authClient } from "../client";
+
+export const postImage = async (imageFile: File) => {
+  const formData = new FormData();
+  formData.append("image", imageFile);
+
+  return await authClient.post("/api/v1/images", formData, {
+    headers: {
+      "Content-Type": "multipart/form-data",
+    },
+  });
+};

--- a/src/api/letter/letter.tsx
+++ b/src/api/letter/letter.tsx
@@ -46,14 +46,14 @@ export const uploadImage = async ({ imageUrl }: { imageUrl: string }) => {
   });
 };
 
-//편지 열람 가능 검증
+// 편지 열람 가능 검증
 export const verifyLetter = async (letterCode: string) => {
   return await authClient.put(`/api/v1/letters/verify`, {
     letterCode: letterCode,
   });
 };
 
-//검증된 편지 열람
+// 검증된 편지 열람
 export const getVerifyedLetter = async (letterId: string) => {
   return await authClient.get(`/api/v1/letters/${letterId}/verify`);
 };
@@ -63,4 +63,9 @@ export const saveVerifyedLetter = async (letterId: string) => {
   return await authClient.post(`/api/v1/letters/verify/receive`, {
     letterId: letterId,
   });
+};
+
+// 모든 편지 수 조회
+export const getLetterCount = async () => {
+  return await authClient.get(`/api/v1/letters/count`);
 };

--- a/src/app/planet/page.tsx
+++ b/src/app/planet/page.tsx
@@ -158,15 +158,39 @@ const PlanetPage = () => {
   };
 
   /* 페이지네이션 */
-  const handlePrevPage = () => {
-    if (currentPage > 1) {
-      setCurrentPage(currentPage - 1);
-    }
-  };
+  // const handlePrevPage = () => {
+  //   if (currentPage > 1) {
+  //     setCurrentPage(currentPage - 1);
+  //   }
+  // };
+
+  // const handleNextPage = () => {
+  //   if (currentPage < totalPages) {
+  //     setCurrentPage(currentPage + 1);
+  //   }
+  // };
+  const [isLeaving, setIsLeaving] = useState(false);
+  const [isNext, setIsNext] = useState(false);
 
   const handleNextPage = () => {
     if (currentPage < totalPages) {
-      setCurrentPage(currentPage + 1);
+      setIsNext(true);
+      setIsLeaving(true); // 페이지 전환 애니메이션 시작
+      setTimeout(() => {
+        setCurrentPage(currentPage + 1);
+        setIsLeaving(false); // 애니메이션 끝
+      }, 400);
+    }
+  };
+
+  const handlePrevPage = () => {
+    if (currentPage > 1) {
+      setIsNext(false);
+      setIsLeaving(true); // 페이지 전환 애니메이션 시작
+      setTimeout(() => {
+        setCurrentPage(currentPage - 1);
+        setIsLeaving(false); // 애니메이션 끝
+      }, 400);
     }
   };
 
@@ -320,7 +344,7 @@ const PlanetPage = () => {
                 />
               </TagList>
               {/* <PlanetWrapper currentPage={currentPage} {...swipeHandlers}> */}
-              <PlanetWrapper>
+              <PlanetWrapper isLeaving={isLeaving} isNext={isNext}>
                 <Droppable droppableId="droppable-planet">
                   {(provided) => (
                     <div ref={provided.innerRef} {...provided.droppableProps}>
@@ -434,13 +458,22 @@ const TagList = styled.div`
   scrollbar-width: none; /* Firefox */
 `;
 
-const PlanetWrapper = styled.div`
+const PlanetWrapper = styled.div<{ isLeaving: boolean; isNext: boolean }>`
   width: 100%;
   height: 100%;
   position: relative;
+  transition: opacity 0.5s ease-in-out, transform 0.5s ease-in-out;
+  opacity: ${({ isLeaving }) => (isLeaving ? 0 : 1)};
+  transform: ${({ isLeaving, isNext }) => {
+    if (isNext) {
+      return isLeaving ? "translateX(50%)" : "translateX(0)";
+    } else {
+      return isLeaving ? "translateX(-50%)" : "translateX(0)";
+    }
+  }};
 `;
 
-// const PlanetWrapper = styled.div<{ currentPage: number }>`
+// const PlanetWrapper = styled.div<{ currentPage: number }>`;
 //   width: 100%;
 //   height: 100%;
 //   position: relative;

--- a/src/app/planet/page.tsx
+++ b/src/app/planet/page.tsx
@@ -30,6 +30,7 @@ import {
   getInitUserToast,
   setInitUserToast,
 } from "@/utils/storage";
+import { getLetterCount } from "@/api/letter/letter";
 
 const PlanetPage = () => {
   const router = useRouter();
@@ -49,6 +50,18 @@ const PlanetPage = () => {
   const { show, message, close } = useRecoilValue(toastState);
   const setToast = useSetRecoilState(toastState);
 
+  const fetchGetLetterCount = async () => {
+    try {
+      const response = await getLetterCount();
+      console.log("모든 편지 수 조회 성공:", response.data);
+      setCountLetter(response.data.count);
+      setCurrentOrbits(response.data.content);
+      setIsLoading(false);
+    } catch (error) {
+      console.error("행성 편지 목록 조회 실패:", error);
+    }
+  };
+
   const fetchPlanetLetterList = async (spaceId: string) => {
     try {
       const response = await getPlanetLetterList({
@@ -58,7 +71,6 @@ const PlanetPage = () => {
       });
       console.log("행성 편지 목록 조회 성공:", response.data);
       setCurrentOrbits(response.data.content);
-      setCountLetter(response.data.totalElements);
       setTotalPages(
         response.data.totalElements === 0 ? 1 : response.data.totalPages
       );
@@ -100,6 +112,7 @@ const PlanetPage = () => {
       }
     };
 
+    fetchGetLetterCount();
     fetchMainId();
     fetchOrbitLetter();
   }, []);
@@ -410,9 +423,6 @@ const TagList = styled.div`
 const PlanetWrapper = styled.div`
   width: 100%;
   height: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
   position: relative;
 `;
 

--- a/src/app/planet/page.tsx
+++ b/src/app/planet/page.tsx
@@ -216,7 +216,11 @@ const PlanetPage = () => {
           const updatedOrbitMessages = orbitMessages?.filter(
             (_, index) => index !== source.index
           );
-          setCurrentOrbits((prevOrbits = []) => [draggedOrbit, ...prevOrbits]);
+
+          setCurrentOrbits((prevOrbits = []) => {
+            const newOrbits = [draggedOrbit, ...prevOrbits];
+            return newOrbits.slice(0, 5); // 최대 5개까지만 보이도록 설정
+          });
 
           // 궤도 이동 애니메이션을 위해 잠시 대기
           setTimeout(() => {

--- a/src/app/planet/page.tsx
+++ b/src/app/planet/page.tsx
@@ -277,9 +277,19 @@ const PlanetPage = () => {
             <Container>
               <Top>
                 <Title>
-                  {userName}님의 스페이스에
-                  <br />
-                  <Em>{countLetter}개의 편지</Em>가 수놓여 있어요!
+                  {countLetter < 3 ? (
+                    <>
+                      {userName}님의 스페이스를
+                      <br />
+                      편지로 수놓아 보세요
+                    </>
+                  ) : (
+                    <>
+                      {userName}님의 스페이스에
+                      <br />
+                      <Em>{countLetter}개의 편지</Em>가 수놓여 있어요!
+                    </>
+                  )}
                 </Title>
                 <Icon
                   src="/assets/icons/ic_mypage.svg"

--- a/src/components/common/Tag.tsx
+++ b/src/components/common/Tag.tsx
@@ -212,11 +212,19 @@ const Box = styled.button<{
   ${({ $tagType }) =>
     $tagType === "letter" &&
     css`
+      display: block;
+      max-width: 90px;
       height: 39px;
-      padding: 11px 26px;
+      padding: 11px 15px;
       border-radius: 100px;
       background: ${theme.colors.sub01};
       ${(props) => props.theme.fonts.body07};
+      line-height: 16px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      text-align: center;
+      vertical-align: middle;
 
       &:active {
         background: #565c81;


### PR DESCRIPTION
## 연관 이슈

#36 #37

<br/>

## 개요

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요. -->

<br/>

## ✅ 작업 내용

- [x] 모든 편지 수 조회 API 연동
- [x] 전체 스페이스 등록 편지 수에 따른 headtitle 내용 변경
- [x] 스페이스 편지 추가 시 5개씩만 보이게
- [x] 행성 편지 말줄임표 적용
- [x] 메인 홈 위치 버그 수정
- [x] 페이지 이동 시 애니메이션 추가

<br/>

## 🖥 구현 결과

<!--  구현한 기능이 보이는 스크린샷을 업로드해주세요. -->

https://github.com/user-attachments/assets/e1735570-a4db-4eb7-952a-fe20ee47528c


<br/>

### 리뷰 요구사항

<!-- 리뷰 시에 유심히 봐주었으면 하는 부분이 있다면 설명해주세요. -->
- 편지를 Droppable 영역으로 끌고 왔을 때 왼쪽 상단에 편지가 잠시 머무는 현상이 있는데 어떻게 가운데로 머물게 할 수 있는지 모르겠어요. css가 안 먹혀요..

<br/>

### 📝 기타 사항

<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업 등을 적어주세요. -->
- 스와이프로 페이지 전환되게 또 시도했는데 가로로 넓게 펴지지가 않아서 그냥 애니메이션으로 좌우에서 나오는 느낌으로 우선 작업했습니다.!

<br/>

<br/>
