### PR TITLE
[Fix] 모바일에서 이미지 용량으로 인한 업로드 이슈 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.13.0",
         "axios": "^1.7.7",
+        "browser-image-compression": "^2.0.2",
         "cookie": "^1.0.0",
         "eslint-config-airbnb": "^19.0.4",
         "eslint-config-prettier": "^9.1.0",
@@ -1619,6 +1620,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/browser-image-compression": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
+      "integrity": "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==",
+      "dependencies": {
+        "uzip": "0.20201231.0"
       }
     },
     "node_modules/busboy": {
@@ -5337,6 +5346,11 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
+    },
+    "node_modules/uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng=="
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "axios": "^1.7.7",
+    "browser-image-compression": "^2.0.2",
     "cookie": "^1.0.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^9.1.0",

--- a/src/app/letter/register/page.tsx
+++ b/src/app/letter/register/page.tsx
@@ -6,13 +6,14 @@ import { theme } from "@/styles/theme";
 import NavigatorBar from "@/components/common/NavigatorBar";
 import Input from "@/components/common/Input";
 import Button from "@/components/common/Button";
-import { useParams, useRouter, useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import Image from "next/image";
 import { useRecoilState } from "recoil";
 import { registerLetterState } from "@/recoil/letterStore";
 import { useToast } from "@/hooks/useToast";
 import { postImage } from "@/api/image/image";
 import Loader, { LoaderContainer } from "@/components/common/Loader";
+import imageCompression from "browser-image-compression";
 
 const LetterRegisterPage = () => {
   const router = useRouter();
@@ -100,8 +101,13 @@ const LetterRegisterPage = () => {
 
       const imageUrls: string[] = [];
       for (const file of selectedImages) {
+        const compressedFile = await imageCompression(file, {
+          maxSizeMB: 1,
+          maxWidthOrHeight: 1024,
+          useWebWorker: true,
+        });
         try {
-          const response = await postImage(file);
+          const response = await postImage(compressedFile);
           console.log("이미지 업로드 성공", response.data);
           imageUrls.push(response.data.imageUrl);
         } catch (error) {

--- a/src/app/send/letter/page.tsx
+++ b/src/app/send/letter/page.tsx
@@ -23,6 +23,7 @@ import { useToast } from "@/hooks/useToast";
 import { postImage } from "@/api/image/image";
 import ConfirmModal from "@/components/common/ConfirmModal";
 import { draftModalState } from "@/recoil/draftStore";
+import imageCompression from "browser-image-compression";
 
 const SendLetterPage = () => {
   const router = useRouter();
@@ -157,7 +158,12 @@ const SendLetterPage = () => {
       const imageUrls: string[] = [];
       for (const file of selectedImages) {
         try {
-          const response = await postImage(file);
+          const compressedFile = await imageCompression(file, {
+            maxSizeMB: 0.5,
+            maxWidthOrHeight: 800,
+            useWebWorker: true,
+          });
+          const response = await postImage(compressedFile);
           console.log("이미지 업로드 성공", response.data);
           imageUrls.push(response.data.imageUrl);
         } catch (error) {


### PR DESCRIPTION
## 연관 이슈

close #61

<br/>

## 개요

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요. -->
모바일에서 이미지 용량으로 인한 업로드 이슈 수정

<br/>


### 📝 기타 사항

<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업 등을 적어주세요. -->
- 웹에서랑 모바일에서 같은 사진이어도 용량에 차이가 있어서 업로드가 안 되는 이슈를 확인했습니다! 그래서 ```browser-image-compression``` 라이브러리를 사용해 이미지 파일을 압축해서 서버로 전달하도록 코드 수정하였습니다. 편지 조회에서 해당 이미지 확인해보니 깨짐 없는 거 확인했습니다! 조회할 떄 이미지 불러올 때 로딩은 좀 걸리는 거 같은데 이 부분은 어떻게 해결할지 의논해보면 좋을 것 같아요!
<br/>

<br/>
