### PR TITLE
[Feat] middleware로 토큰 유무에 따른 리다이렉트 설정

### DIFF
--- a/src/api/client.tsx
+++ b/src/api/client.tsx
@@ -83,12 +83,12 @@ authClient.interceptors.response.use(
         return Promise.reject(refreshError);
       }
     } else {
-      const accessToken = getAccessToken();
-      if (!accessToken) {
-        window.location.href = "/login";
-      } else {
-        //window.location.href = "/error";
-      }
+      // const accessToken = getAccessToken();
+      // if (!accessToken) {
+      // window.location.href = "/login";
+      // } else {
+      //window.location.href = "/error";
+      // }
     }
     return Promise.reject(error);
   }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,13 +19,13 @@ export default function Home() {
   const router = useRouter();
   const accessToken = getAccessToken();
 
-  useEffect(() => {
-    if (!accessToken) {
-      router.push("/login");
-    } else {
-      router.push("/planet");
-    }
-  }, []);
+  // useEffect(() => {
+  //   if (!accessToken) {
+  //     router.push("/login");
+  //   } else {
+  //     router.push("/planet");
+  //   }
+  // }, []);
 
   return (
     <Container>

--- a/src/app/planet/page.tsx
+++ b/src/app/planet/page.tsx
@@ -428,11 +428,11 @@ const PlanetPage = () => {
   };
 
   //토큰 유효한지 확인
-  useEffect(() => {
-    if (!accessToken) {
-      router.push("/login");
-    }
-  }, []);
+  // useEffect(() => {
+  //   if (!accessToken) {
+  //     router.push("/login");
+  //   }
+  // }, []);
 
   return (
     <>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,76 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { getAccessToken } from "./utils/storage";
+
+export default function middleware(request: NextRequest) {
+  const { nextUrl, cookies } = request;
+  const accessToken = cookies.get("lettering-access")?.value;
+  const { pathname, searchParams } = request.nextUrl;
+
+  /* 정적 파일 요청인지 확인 */
+  if (
+    request.nextUrl.pathname.startsWith("/images") ||
+    request.nextUrl.pathname.endsWith(".svg") ||
+    request.nextUrl.pathname.endsWith(".png") ||
+    request.nextUrl.pathname === "/manifest.json"
+  ) {
+    return NextResponse.next();
+  }
+
+  /* /verify/letter 페이지 접근 시 토큰 유무에 따라 처리 */
+  if (pathname === "/verify/letter") {
+    const urlParam = searchParams.get("url");
+
+    // 액세스 토큰이 없는 경우
+    if (!accessToken) {
+      // `url` 파라미터가 있으면 해당 URL로, 없으면 기본 `/login`으로 이동
+      const redirectUrl = urlParam ? `/login?url=${urlParam}` : "/login";
+      return NextResponse.redirect(new URL(redirectUrl, request.url));
+    }
+  }
+
+  if (
+    request.nextUrl.pathname.startsWith("/error") ||
+    request.nextUrl.pathname.startsWith("/verify")
+  ) {
+    return NextResponse.next();
+  }
+  
+  /* 로그인 필요 없는 페이지 */
+  if (
+    request.nextUrl.pathname === "/login" ||
+    request.nextUrl.pathname.startsWith("/signup") ||
+    request.nextUrl.pathname.startsWith("/kakao")
+  ) {
+    // 로그인 되어 있는 경우 메인 페이지로 리다이렉트
+    if (accessToken) {
+      const redirectUrl = "/planet";
+      return NextResponse.redirect(new URL(redirectUrl, request.url));
+    } else {
+      // 로그인이 필요 없는 페이지는 그냥 다음 요청으로 진행
+      return NextResponse.next();
+    }
+  }
+
+  /* 로그인 필요한 페이지 */
+  if (!accessToken) {
+    // 로그인 페이지로 리다이렉트
+    return NextResponse.redirect(new URL("/login", request.url));
+  }
+
+  // 로그인 되어 있는 경우 요청 페이지로 진행
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except for the ones starting with:
+     * - api (API routes)
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - favicon.ico (favicon file)
+     * - robots.txt (robots file)
+     */
+    "/((?!api|_next/static|_next/image|favicon.ico|robots.txt|images|manifest.json).*)",
+  ],
+};


### PR DESCRIPTION
## 연관 이슈

close #83

<br/>

## 개요

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요. -->
middleware로 토큰 유무에 따른 리다이렉트 설정
(테스트용)
<br/>

### 📝 기타 사항

<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업 등을 적어주세요. -->
- 회원탈퇴 상황이 아님에도 공유 편지 url 접근 시 로그인 > 회원가입으로 경로로 이동되곤 하는 문제가 토큰이 만료되는 경우 때문이 아닐까 하여.. 한번 테스트로 설정해봅니다!

- 사실 미들웨어를 만드는 게 맞긴 한데 (예를 들어 지금은 ```/planet```으로 갔다가 토큰이 없으면 ```/login```으로 이동하는 형태라 토큰이 없는 상황에서도 잠깐 ```/planet```에 접속되는 문제, ```/planet```이 아닌 ```/send ~```등의 그 외 토큰이 필요한 페이지에 접속할 때에는 토큰 없이도 접속이 된다는 문제 등이 있기 때문) 우선 문제 상황 테스트용으로 브랜치 따로 파서 만들어보았습니다!

- 편지 인증 과정에서 쪼금 복잡할 거 같아서 이렇게 했을 때 잘 될지 모르겠으나.. 한번 해보고 이상해지면 기존 코드로 복구해두는 걸로 할게용
<br/>

<br/>
