### PR TITLE
[!Hotfix] client를 authClient로 변경

### DIFF
--- a/src/api/letter/letter.tsx
+++ b/src/api/letter/letter.tsx
@@ -43,12 +43,9 @@ export const uploadImage = async ({ imageUrl }: { imageUrl: string }) => {
 };
 
 // 편지 열람 가능 검증
-export const verifyLetter = async (letterCode: string, accessToken: string) => {
-  return await client.put(`/api/v1/letters/verify`, {
+export const verifyLetter = async (letterCode: string) => {
+  return await authClient.put(`/api/v1/letters/verify`, {
     letterCode: letterCode,
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
   });
 };
 

--- a/src/api/planet/space/space.tsx
+++ b/src/api/planet/space/space.tsx
@@ -5,11 +5,7 @@ import { getAccessToken } from "@/utils/storage";
 export const getMainId = async () => {
   const accessToken = getAccessToken();
 
-  const response = await client.get(`/api/v1/spaces/main`, {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
-  });
+  const response = await authClient.get(`/api/v1/spaces/main`);
 
   return response;
 };

--- a/src/api/verify/verify.tsx
+++ b/src/api/verify/verify.tsx
@@ -1,18 +1,10 @@
-import client from "../client";
+import client, { authClient } from "../client";
 
 //편지 검증 - > 여기서 id를 받음
-export const verifyLetter = async (letterCode: string, accessToken: string) => {
-  return await client.put(
-    `/api/v1/letters/verify`,
-    {
-      letterCode: letterCode,
-    },
-    {
-      headers: {
-        Authorization: `${accessToken}`,
-      },
-    }
-  );
+export const verifyLetter = async (letterCode: string) => {
+  return await authClient.put(`/api/v1/letters/verify`, {
+    letterCode: letterCode,
+  });
 };
 
 //편지 수령 처리

--- a/src/app/verify/letter/page.tsx
+++ b/src/app/verify/letter/page.tsx
@@ -80,7 +80,7 @@ const VerifyLetter = () => {
 
         // letterCode가 있을 경우 추가 검증 진행
         if (url) {
-          verifyLetter(url, accessToken)
+          verifyLetter(url)
             .then((res) => {
               if (res.data.letterId) {
                 setletterId(res.data.letterId);


### PR DESCRIPTION
## 연관 이슈

close #86

<br/>

## 개요

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요. -->

<br/>

## ✅ 작업 내용

- [x] client 모듈을 authClient로 변경

<br/>


### 📝 기타 사항

<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업 등을 적어주세요. -->
이렇게 바꾸면 페이지를 찾을 수 없다는 오류는 해결되었습니다! 이전 PR 작업 코드에서는 500에러가 나오면서 ```/error``` 경로로 나오더라구요. Swagger 돌려보니까 500 나오는 경우가 토큰이 없을 때였어요! 그래서 authClient로 변경했습니다. (```authClient```로 보내야 요청 인터셉터로 토큰이 들어가서 토큰이 있어야 요청갈 수 있을 거예요!)

<br/>
