### PR TITLE
[Fix] 편지 관련 QA

### DIFF
--- a/src/app/guide/page.tsx
+++ b/src/app/guide/page.tsx
@@ -73,9 +73,9 @@ const GuidePage = () => {
   //Letter
   const letterData = LETTER_DUMMY[0];
   const imageData = [
-    'https://via.assets.so/album.png?id=6&q=95&w=360&h=360&fit=fill',
-    'https://via.assets.so/album.png?id=2&q=95&w=360&h=360&fit=fill',
-    'https://via.assets.so/album.png?id=3&q=95&w=360&h=360&fit=fill'
+    'https://lettering-images.s3.amazonaws.com/0192e660-0efb-7729-b107-19f5ed4a7fb9/4c182685-da2a-49fd-8251-ecc8914733c6',
+    'https://lettering-images.s3.amazonaws.com/0192e660-0efb-7729-b107-19f5ed4a7fb9/4c182685-da2a-49fd-8251-ecc8914733c6',
+    'https://lettering-images.s3.amazonaws.com/0192e660-0efb-7729-b107-19f5ed4a7fb9/4c182685-da2a-49fd-8251-ecc8914733c6'
   ];
 
   //bottomSheet
@@ -235,7 +235,7 @@ const GuidePage = () => {
         isImage={true}
       />
       <Letter
-        showType="previewReceive"
+        showType="send"
         contentType="all"
         id={letterData.id.toString()}
         templateType={letterData.templateType}
@@ -243,9 +243,21 @@ const GuidePage = () => {
         content={letterData.content}
         date={letterData.date}
         isImage={false}
+        height="450px"
       />
       <Letter
-        showType="previewReceive"
+        showType="send"
+        contentType="one"
+        id={letterData.id.toString()}
+        templateType={letterData.templateType}
+        name={letterData.sender}
+        images={imageData}
+        date={letterData.date}
+        isImage={true}
+        height="450px"
+      />
+      <Letter
+        showType="url"
         contentType="one"
         id={letterData.id.toString()}
         templateType={letterData.templateType}
@@ -253,26 +265,6 @@ const GuidePage = () => {
         content={letterData.content}
         date={letterData.date}
         isImage={false}
-      />
-      <Letter
-        showType="previewSend"
-        contentType="all"
-        id={letterData.id.toString()}
-        templateType={letterData.templateType}
-        name={letterData.sender}
-        images={imageData}
-        date={letterData.date}
-        isImage={true}
-      />
-      <Letter
-        showType="previewSend"
-        contentType="one"
-        id={letterData.id.toString()}
-        templateType={letterData.templateType}
-        name={letterData.sender}
-        images={imageData}
-        date={letterData.date}
-        isImage={true}
       />
       <h3>BottomSheet</h3>
       <ButtonContainer>

--- a/src/app/independent/[id]/page.tsx
+++ b/src/app/independent/[id]/page.tsx
@@ -343,6 +343,7 @@ const LetterContainer = styled.div`
   @media (max-height: 824px) {
     max-width: 320px;
     min-height: 350px;
+    max-height: 350px;
   }
 
   @media (max-height: 780px) {

--- a/src/app/independent/[id]/page.tsx
+++ b/src/app/independent/[id]/page.tsx
@@ -5,7 +5,6 @@ import Button from '@/components/common/Button';
 import Loader from '@/components/common/Loader';
 import NavigatorBar from '@/components/common/NavigatorBar';
 import Letter from '@/components/letter/Letter';
-import { useToast } from '@/hooks/useToast';
 import { registerLetterState } from '@/recoil/letterStore';
 import { theme } from '@/styles/theme';
 import { IndependentLetterType, LetterDetailType } from '@/types/letter';
@@ -20,7 +19,6 @@ const IndependentLetterPage = () => {
   const { id } = useParams();
   const letterId = Array.isArray(id) ? id[0] : id;
   const [key, setKey] = useState(1);
-  //const searchParams = useSearchParams();
   const [letterData, setLetterData] = useState<IndependentLetterType | null>(
     null
   );
@@ -29,7 +27,29 @@ const IndependentLetterPage = () => {
   const [letterState, setLetterState] = useRecoilState(registerLetterState);
   const [isPopup, setIsPopup] = useState(false);
   const [isDelete, setIsDelete] = useState(false);
-  const { showToast } = useToast();
+
+  const [maxLinesPerPage, setMaxLinesPerPage] = useState(12);
+
+  useEffect(() => {
+    const updateMaxLines = () => {
+      if (window.innerHeight > 800) {
+        setMaxLinesPerPage(10);
+      } else if (window.innerHeight > 680) {
+        setMaxLinesPerPage(8);
+      } else if (window.innerHeight > 600) {
+        setMaxLinesPerPage(6);
+      } else {
+        setMaxLinesPerPage(5);
+      }
+    };
+
+    updateMaxLines();
+    window.addEventListener('resize', updateMaxLines);
+
+    return () => {
+      window.removeEventListener('resize', updateMaxLines);
+    };
+  }, []);
 
   //편지 수정 버튼 클릭
   const handleModify = () => {
@@ -125,8 +145,8 @@ const IndependentLetterPage = () => {
       <MainWrapper>
         <LetterContainer>
           <Letter
+            key={`${key}-${maxLinesPerPage}`}
             showType="receive"
-            key={key}
             contentType="all"
             id={letterId || ''}
             templateType={letterData.templateType}
@@ -137,6 +157,7 @@ const IndependentLetterPage = () => {
             isImage={isImage}
             width="100%"
             height="100%"
+            maxLines={maxLinesPerPage}
           />
         </LetterContainer>
         {letterData.images.length > 0 && letterData.content.length > 0 ? (
@@ -242,6 +263,10 @@ const MainWrapper = styled.div`
   padding: 18px;
   overflow-y: auto;
   overflow-x: hidden;
+
+  @media (max-height: 680px) {
+    justify-content: flex-start;
+  }
 `;
 
 const PopupContainer = styled.div`
@@ -307,44 +332,6 @@ const PopupBtn = styled.button`
   }
 `;
 
-/*const Header = styled.div`
-   display: flex;
-  flex-direction: row;
-  padding-bottom: 15px;
-  width: 100%;
-`;
-
-const HeaderTitle = styled.div`
-  width: 100%;
-  ${(props) => props.theme.fonts.heading01};
-  flex: 2;
-  span {
-    ${(props) => props.theme.fonts.heading02};
-    white-space: nowrap;
-  }
-
-  @media (max-height: 780px) {
-    ${theme.fonts.title01};
-    span {
-      ${(props) => props.theme.fonts.body03};
-    }
-  }
-
-  @media (max-height: 628px) {
-    ${theme.fonts.subtitle};
-    span {
-      ${(props) => props.theme.fonts.body07};
-    }
-  }
-
-  @media (max-height: 580px) {
-    ${theme.fonts.subtitle};
-    span {
-      ${(props) => props.theme.fonts.body07};
-    }
-  }
-`; */
-
 const LetterContainer = styled.div`
   display: flex;
   justify-content: center;
@@ -366,11 +353,11 @@ const LetterContainer = styled.div`
 
   @media (max-height: 680px) {
     max-width: 300px;
-    min-height: 330px;
-    max-height: 330px;
+    min-height: 300px;
+    max-height: 300px;
   }
 
-  @media (max-height: 580px) {
+  @media (max-height: 600px) {
     max-width: 250px;
     min-height: 250px;
     max-height: 250px;
@@ -381,17 +368,6 @@ const LetterContainer = styled.div`
     min-height: 250px;
     max-height: 250px;
   }
-`;
-
-const LetterCount = styled.div`
-  display: flex;
-  ${(props) => props.theme.fonts.caption03};
-  color: ${(props) => props.theme.colors.gray400};
-  flex: 1;
-  flex-direction: column;
-  text-align: end;
-  justify-content: end;
-  padding: 5px;
 `;
 
 const ButtonContainer = styled.div`

--- a/src/app/letter/[id]/page.tsx
+++ b/src/app/letter/[id]/page.tsx
@@ -403,6 +403,7 @@ const LetterContainer = styled.div`
   @media (max-height: 824px) {
     max-width: 320px;
     min-height: 350px;
+    max-height: 350px;
   }
 
   @media (max-height: 780px) {

--- a/src/app/letter/[id]/page.tsx
+++ b/src/app/letter/[id]/page.tsx
@@ -27,6 +27,29 @@ const LetterPage = () => {
   const [isDelete, setIsDelete] = useState(false);
   const { showToast } = useToast();
 
+  const [maxLinesPerPage, setMaxLinesPerPage] = useState(12);
+
+  useEffect(() => {
+    const updateMaxLines = () => {
+      if (window.innerHeight > 800) {
+        setMaxLinesPerPage(10);
+      } else if (window.innerHeight > 680) {
+        setMaxLinesPerPage(8);
+      } else if (window.innerHeight > 600) {
+        setMaxLinesPerPage(6);
+      } else {
+        setMaxLinesPerPage(5);
+      }
+    };
+
+    updateMaxLines();
+    window.addEventListener('resize', updateMaxLines);
+
+    return () => {
+      window.removeEventListener('resize', updateMaxLines);
+    };
+  }, []);
+
   const handleButtonClick = (id: string) => {
     router.push(`/letter/${id}`);
   };
@@ -175,8 +198,8 @@ const LetterPage = () => {
       <MainWrapper>
         <LetterContainer>
           <Letter
+            key={`${key}-${maxLinesPerPage}`}
             showType="receive"
-            key={key}
             contentType="all"
             pageType="space"
             id={letterId || ''}
@@ -189,6 +212,7 @@ const LetterPage = () => {
             nextLetterId={letterData.next_letter?.letter_id}
             width="100%"
             height="100%"
+            maxLines={maxLinesPerPage}
           />
         </LetterContainer>
         {letterData.images.length > 0 && letterData.content.length > 0 ? (
@@ -289,6 +313,10 @@ const MainWrapper = styled.div`
   padding: 0 18px;
   overflow-y: auto;
   overflow-x: hidden;
+
+  @media (max-height: 680px) {
+    justify-content: flex-start;
+  }
 `;
 
 const IconWrapper = styled.div`
@@ -378,18 +406,18 @@ const LetterContainer = styled.div`
   }
 
   @media (max-height: 780px) {
-    //max-width: 300px;
+    max-width: 300px;
     min-height: 330px;
     max-height: 330px;
   }
 
   @media (max-height: 680px) {
     max-width: 300px;
-    min-height: 330px;
-    max-height: 330px;
+    min-height: 300px;
+    max-height: 300px;
   }
 
-  @media (max-height: 580px) {
+  @media (max-height: 600px) {
     max-width: 250px;
     min-height: 250px;
     max-height: 250px;

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -19,10 +19,6 @@ const MyPage = () => {
   const [letterCount, setLetterCount] = useState(0);
   const [loading, setLoading] = useState(true);
 
-  const goToProfile = () => {
-    router.push('/profile');
-  };
-
   useEffect(() => {
     fetchUserInfo();
     fetchGetCount();
@@ -225,23 +221,24 @@ const MainWrapper = styled.div`
 `;
 
 const ProfileHeader = styled.div`
+  height: 144px;
   display: flex;
   flex-direction: row;
-  justify-content: space-between;
+  justify-content: flex-start;
   align-items: center;
+  gap: 25px;
+
+  @media (max-width: 370px) {
+    gap: 10px;
+  }
 `;
 
 const ProfileImage = styled.img`
-  width: 100%;
+  width: 143px;
   height: auto;
 
-  @media (max-height: 760px) {
-    width: 180px;
-  }
-
-  @media (max-width: 400px) {
-    width: 130px;
-    height: 130px;
+  @media (max-width: 370px) {
+    width: 100px;
   }
 `;
 
@@ -250,6 +247,7 @@ const ProfileInfo = styled.div`
   flex-direction: column;
   justify-content: center;
   gap: 4px;
+  white-space: nowrap;
 `;
 
 const ProfileName = styled.div`

--- a/src/app/mypage/send/[id]/page.tsx
+++ b/src/app/mypage/send/[id]/page.tsx
@@ -1,16 +1,15 @@
-"use client";
+'use client';
 
-import { getSentLetterDetail } from "@/api/mypage/user";
-import KakaoShareButton from "@/components/common/KakaoShareButton";
-import Loader from "@/components/common/Loader";
-import NavigatorBar from "@/components/common/NavigatorBar";
-import Letter from "@/components/letter/Letter";
-import { theme } from "@/styles/theme";
-import { SentDetailLetterType } from "@/types/letter";
-import { getAccessToken } from "@/utils/storage";
-import { useParams } from "next/navigation";
-import { Suspense, useEffect, useState } from "react";
-import styled from "styled-components";
+import { getSentLetterDetail } from '@/api/mypage/user';
+import KakaoShareButton from '@/components/common/KakaoShareButton';
+import Loader from '@/components/common/Loader';
+import NavigatorBar from '@/components/common/NavigatorBar';
+import Letter from '@/components/letter/Letter';
+import { theme } from '@/styles/theme';
+import { SentDetailLetterType } from '@/types/letter';
+import { useParams } from 'next/navigation';
+import { Suspense, useEffect, useState } from 'react';
+import styled from 'styled-components';
 
 const SendDetailPage = () => {
   const { id } = useParams();
@@ -18,8 +17,30 @@ const SendDetailPage = () => {
   const [key, setKey] = useState(1);
   const [letterData, setLetterData] = useState<SentDetailLetterType>();
   const [isImage, setIsImage] = useState(false);
-  const accessToken = getAccessToken();
-  const [letterCode, setLetterCode] = useState("");
+  const [letterCode, setLetterCode] = useState('');
+
+  const [maxLinesPerPage, setMaxLinesPerPage] = useState(12);
+
+  useEffect(() => {
+    const updateMaxLines = () => {
+      if (window.innerHeight > 780) {
+        setMaxLinesPerPage(10);
+      } else if (window.innerHeight > 630) {
+        setMaxLinesPerPage(7);
+      } else if (window.innerHeight > 580) {
+        setMaxLinesPerPage(5);
+      } else {
+        setMaxLinesPerPage(6);
+      }
+    };
+
+    updateMaxLines();
+    window.addEventListener('resize', updateMaxLines);
+
+    return () => {
+      window.removeEventListener('resize', updateMaxLines);
+    };
+  }, []);
 
   const changeImageorContent = () => {
     setIsImage(!isImage);
@@ -50,16 +71,16 @@ const SendDetailPage = () => {
       <MainWrapper>
         <Header>
           <LetterCount>
-            편지 정보 | {letterData.content.length}자{" "}
+            편지 정보 | {letterData.content.length}자{' '}
             {letterData.images.length > 0 &&
               ` · 사진 ${letterData.images.length}장`}
           </LetterCount>
         </Header>
         <LetterContainer>
           <Letter
+            key={`${key}-${maxLinesPerPage}`}
             showType="send"
-            key={key}
-            id={letterId || ""}
+            id={letterId || ''}
             templateType={letterData.templateType}
             name={letterData.receiverName}
             content={letterData.content}
@@ -69,6 +90,7 @@ const SendDetailPage = () => {
             isImage={isImage}
             width="100%"
             height="100%"
+            maxLines={maxLinesPerPage}
           />
         </LetterContainer>
         <WhiteSpace />
@@ -76,7 +98,7 @@ const SendDetailPage = () => {
           <ChangeButtonWrapper onClick={changeImageorContent}>
             <img src="/assets/icons/ic_change_image.svg"></img>
             <div>
-              클릭하면 {isImage ? "편지 내용" : "사진"}을 확인할 수 있어요!
+              클릭하면 {isImage ? '편지 내용' : '사진'}을 확인할 수 있어요!
             </div>
           </ChangeButtonWrapper>
         ) : (
@@ -158,6 +180,7 @@ const LetterContainer = styled.div`
 
   @media (max-height: 824px) {
     max-width: 320px;
+    max-height: 350px;
     min-height: 350px;
   }
 

--- a/src/app/planet/move/page.tsx
+++ b/src/app/planet/move/page.tsx
@@ -1,43 +1,43 @@
-"use client";
+'use client';
 
-import React, { Suspense, useEffect, useState } from "react";
-import styled from "styled-components";
-import { theme } from "@/styles/theme";
-import NavigatorBar from "@/components/common/NavigatorBar";
-import Button from "@/components/common/Button";
-import { useRouter, useSearchParams } from "next/navigation";
-import PlanetBox from "@/components/planet/PlanetBox";
-import Loader, { LoaderContainer } from "@/components/common/Loader";
+import React, { Suspense, useEffect, useState } from 'react';
+import styled from 'styled-components';
+import { theme } from '@/styles/theme';
+import NavigatorBar from '@/components/common/NavigatorBar';
+import Button from '@/components/common/Button';
+import { useRouter, useSearchParams } from 'next/navigation';
+import PlanetBox from '@/components/planet/PlanetBox';
+import Loader, { LoaderContainer } from '@/components/common/Loader';
 import {
   putLetterToIndep,
-  putLetterToPlanet,
-} from "@/api/planet/letter/spaceLetter";
-import Image from "next/image";
-import { getSpaceList } from "@/api/planet/space/space";
-import { useToast } from "@/hooks/useToast";
-import { Planet } from "@/types/planet";
+  putLetterToPlanet
+} from '@/api/planet/letter/spaceLetter';
+import Image from 'next/image';
+import { getSpaceList } from '@/api/planet/space/space';
+import { useToast } from '@/hooks/useToast';
+import { Planet } from '@/types/planet';
 
 const PlanetMovePage = () => {
   const router = useRouter();
   const { showToast } = useToast();
   const searchParams = useSearchParams();
-  const letterId = searchParams.get("letter");
-  const senderName = searchParams.get("senderName");
+  const letterId = searchParams.get('letter');
+  const senderName = searchParams.get('senderName');
 
   const [planets, setPlanets] = useState<Planet[]>();
-  const [checkedPlanet, setCheckedPlanet] = useState<string>("");
+  const [checkedPlanet, setCheckedPlanet] = useState<string>('');
   const [checkedIndep, setCheckedIndep] = useState<boolean>(false);
-  const [checkePlanetName, setCheckedPlanetName] = useState<string>("");
+  const [checkePlanetName, setCheckedPlanetName] = useState<string>('');
 
   useEffect(() => {
     const fetchSpaceList = async () => {
       try {
         const response = await getSpaceList();
-        console.log("전체 스페이스 목록 조회 성공:", response.data);
+        console.log('전체 스페이스 목록 조회 성공:', response.data);
         setPlanets(response.data.spaces);
         setCheckedPlanet(response.data.spaces[0].spaceId);
       } catch (error) {
-        console.error("전체 스페이스 목록 조회 실패:", error);
+        console.error('전체 스페이스 목록 조회 실패:', error);
       }
     };
 
@@ -56,23 +56,23 @@ const PlanetMovePage = () => {
       try {
         // 우선, 편지 궤도(독립 편지)로 보내기
         await putLetterToIndep(letterId);
-        console.log("편지 궤도 보내기 성공");
+        console.log('편지 궤도 보내기 성공');
 
         // checkedPlanet가 있을 경우, 다른 행성으로 이동
         if (checkedPlanet) {
           await putLetterToPlanet({
             letterId: letterId,
-            spaceId: checkedPlanet,
+            spaceId: checkedPlanet
           });
-          console.log("편지 다른 행성 이동 성공");
+          console.log('편지 다른 행성 이동 성공');
 
           showToast(
             `${senderName} 님의 편지가 ${checkePlanetName} 행성으로 이동했어요`,
             {
               icon: false,
               close: false,
-              bottom: "230px",
-              padding: "11px 20px",
+              bottom: '230px',
+              padding: '11px 20px'
             }
           );
         } else {
@@ -81,14 +81,14 @@ const PlanetMovePage = () => {
             {
               icon: false,
               close: false,
-              bottom: "230px",
+              bottom: '230px'
             }
           );
         }
 
-        router.push("/planet");
+        router.push('/planet');
       } catch (error) {
-        console.log("편지 이동 실패", error);
+        console.log('편지 이동 실패', error);
       }
     }
   };
@@ -98,7 +98,7 @@ const PlanetMovePage = () => {
       setCheckedIndep(false);
     } else {
       setCheckedIndep(true);
-      setCheckedPlanet("");
+      setCheckedPlanet('');
     }
   };
 
@@ -135,10 +135,10 @@ const PlanetMovePage = () => {
                 alt="check"
               />
             )}
-            행성 궤도로 보내기
+            새 편지함으로 보내기
           </Top>
           <Small>
-            궤도로 옮겨질 시, 홈에서 끌어당겨 언제든 추가할 수 있어요
+            새 편지함에서 끌어당겨 언제든 다른 행성에 추가할 수 있어요
           </Small>
         </SendOrbitArea>
       </SendOrbitAreaWrapper>
@@ -148,7 +148,7 @@ const PlanetMovePage = () => {
           size="large"
           text="이동하기"
           disabled={
-            (checkedPlanet === "" && checkedIndep === false) ||
+            (checkedPlanet === '' && checkedIndep === false) ||
             checkedPlanet === planets?.[0]?.spaceId
           }
           onClick={handleMovePlanet}

--- a/src/app/send/(process)/preview/page.tsx
+++ b/src/app/send/(process)/preview/page.tsx
@@ -25,9 +25,31 @@ const SendPreviewPage = () => {
   const [letterCode, setLetterCode] = useState<string>('');
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [isSharing, setIsSharing] = useState<boolean>(false);
+  const [maxLinesPerPage, setMaxLinesPerPage] = useState(12);
 
   useEffect(() => {
     setIsImage(!!!(content.length > 0));
+  }, []);
+
+  useEffect(() => {
+    const updateMaxLines = () => {
+      if (window.innerHeight > 670) {
+        setMaxLinesPerPage(12);
+      } else if (window.innerHeight > 628) {
+        setMaxLinesPerPage(8);
+      } else if (window.innerHeight > 580) {
+        setMaxLinesPerPage(7);
+      } else {
+        setMaxLinesPerPage(9);
+      }
+    };
+
+    updateMaxLines();
+    window.addEventListener('resize', updateMaxLines);
+
+    return () => {
+      window.removeEventListener('resize', updateMaxLines);
+    };
   }, []);
 
   const handleFlipLetter = () => {
@@ -119,7 +141,9 @@ const SendPreviewPage = () => {
               $hasChangeButton={content.length > 0 && images.length > 0}
             >
               <Letter
+                key={`${maxLinesPerPage}`}
                 showType="send"
+                contentType="all"
                 id={'0'}
                 templateType={templateType}
                 name={receiverName}
@@ -130,6 +154,7 @@ const SendPreviewPage = () => {
                 height="100%"
                 padding="38px 28px"
                 nameSize="18px"
+                maxLines={maxLinesPerPage}
               />
             </LetterContainer>
             {content.length > 0 && images.length > 0 && (

--- a/src/app/send/(process)/preview/page.tsx
+++ b/src/app/send/(process)/preview/page.tsx
@@ -115,7 +115,9 @@ const SendPreviewPage = () => {
       <Container>
         <Column>
           <LetterWrapper>
-            <LetterContainer>
+            <LetterContainer
+              $hasChangeButton={content.length > 0 && images.length > 0}
+            >
               <Letter
                 showType="send"
                 id={'0'}
@@ -209,14 +211,15 @@ const LetterWrapper = styled.div`
   }
 `;
 
-const LetterContainer = styled.div`
+const LetterContainer = styled.div<{ $hasChangeButton: boolean }>`
   display: flex;
   justify-content: center;
   align-items: center;
   width: 100%;
   max-width: 345px;
-  min-height: 354px;
-  max-height: 354px;
+  min-height: 443px;
+  max-height: 443px;
+  margin-bottom: ${({ $hasChangeButton }) => ($hasChangeButton ? '0' : '80px')};
 
   @media (max-height: 660px) {
     min-height: 350px;
@@ -235,6 +238,8 @@ const LetterContainer = styled.div`
   @media (max-height: 550px) {
     min-height: 280px;
     max-height: 280px;
+    margin-bottom: ${({ $hasChangeButton }) =>
+      $hasChangeButton ? '0' : '55px'};
   }
 `;
 

--- a/src/app/send/(process)/preview/page.tsx
+++ b/src/app/send/(process)/preview/page.tsx
@@ -117,7 +117,7 @@ const SendPreviewPage = () => {
           <LetterWrapper>
             <LetterContainer>
               <Letter
-                showType="previewSend"
+                showType="send"
                 id={'0'}
                 templateType={templateType}
                 name={receiverName}

--- a/src/app/send/(process)/template/page.tsx
+++ b/src/app/send/(process)/template/page.tsx
@@ -84,6 +84,7 @@ const SendTemplatePage = () => {
                 key={`${maxLinesPerPage}-${fontSize}`}
                 showType="send"
                 contentType="one"
+                isTemplate={true}
                 id={'0'}
                 templateType={template}
                 name={receiverName}

--- a/src/app/send/(process)/template/page.tsx
+++ b/src/app/send/(process)/template/page.tsx
@@ -16,6 +16,8 @@ const SendTemplatePage = () => {
   const { receiverName, content, images, templateType } =
     useRecoilValue(sendLetterState);
   const setSendLetterState = useSetRecoilState(sendLetterState);
+  const [maxLinesPerPage, setMaxLinesPerPage] = useState(7);
+  const [fontSize, setFontSize] = useState<string>('16px');
 
   const [template, setTemplate] = useState<number>(
     templateType || ALL_TEMPLATES[0]
@@ -29,6 +31,34 @@ const SendTemplatePage = () => {
       setSsrCompleted();
     }
   }, [setSsrCompleted]);
+
+  useEffect(() => {
+    const updateMaxLines = () => {
+      if (window.innerHeight > 725) {
+        setMaxLinesPerPage(8);
+        setFontSize('16px');
+      } else if (window.innerHeight > 628) {
+        setMaxLinesPerPage(7);
+        setFontSize('16px');
+      } else if (window.innerHeight > 580) {
+        setMaxLinesPerPage(6);
+        setFontSize('16px');
+      } else if (window.innerHeight > 550) {
+        setMaxLinesPerPage(5);
+        setFontSize('16px');
+      } else {
+        setMaxLinesPerPage(4);
+        setFontSize('11px');
+      }
+    };
+
+    updateMaxLines();
+    window.addEventListener('resize', updateMaxLines);
+
+    return () => {
+      window.removeEventListener('resize', updateMaxLines);
+    };
+  }, []);
 
   const hanleChangeTemplate = (id: number) => {
     setTemplate(id);
@@ -51,6 +81,7 @@ const SendTemplatePage = () => {
           <LetterWrapper>
             <LetterContainer>
               <Letter
+                key={`${maxLinesPerPage}-${fontSize}`}
                 showType="send"
                 contentType="one"
                 id={'0'}
@@ -62,6 +93,8 @@ const SendTemplatePage = () => {
                 width="100%"
                 height="100%"
                 padding="40px 30px"
+                maxLines={maxLinesPerPage}
+                fontSize={fontSize}
               />
             </LetterContainer>
           </LetterWrapper>

--- a/src/app/send/(process)/template/page.tsx
+++ b/src/app/send/(process)/template/page.tsx
@@ -51,7 +51,7 @@ const SendTemplatePage = () => {
           <LetterWrapper>
             <LetterContainer>
               <Letter
-                showType="previewSend"
+                showType="send"
                 contentType="one"
                 id={'0'}
                 templateType={template}

--- a/src/app/store/content/page.tsx
+++ b/src/app/store/content/page.tsx
@@ -161,16 +161,10 @@ const LetterContentPage = () => {
 
       const imageUrls: string[] = [];
       for (const file of validImages) {
-        const compressedFile = await imageCompression(file, {
-          maxSizeMB: 500,
-          maxWidthOrHeight: 512,
-          useWebWorker: true
-        });
-
         try {
           setImageUploadLoading(true);
 
-          const response = await postImage(compressedFile);
+          const response = await postImage(file);
           console.log('이미지 업로드 성공', response.data);
           imageUrls.push(response.data.imageUrl);
         } catch (error) {
@@ -186,6 +180,9 @@ const LetterContentPage = () => {
         previewImages: newPreviewImages
       }));
     }
+
+    /* 동일한 파일 선택 가능하도록 이전 value 값 초기화 */
+    event.target.value = '';
   };
 
   const handleDeleteImages = (id: number) => {

--- a/src/app/store/preview/page.tsx
+++ b/src/app/store/preview/page.tsx
@@ -97,7 +97,7 @@ const LetterPreviewPage = () => {
           <LetterWrapper>
             <LetterContainer>
               <Letter
-                showType="previewReceive"
+                showType="receive"
                 contentType="all"
                 id={'0'}
                 templateType={templateType}

--- a/src/app/store/preview/page.tsx
+++ b/src/app/store/preview/page.tsx
@@ -27,9 +27,31 @@ const LetterPreviewPage = () => {
 
   const [isImage, setIsImage] = useState<boolean>(false);
   const resetLetterState = useResetRecoilState(registerLetterState);
+  const [maxLinesPerPage, setMaxLinesPerPage] = useState(12);
 
   useEffect(() => {
     setIsImage(!!!(content.length > 0));
+  }, []);
+
+  useEffect(() => {
+    const updateMaxLines = () => {
+      if (window.innerHeight > 670) {
+        setMaxLinesPerPage(12);
+      } else if (window.innerHeight > 628) {
+        setMaxLinesPerPage(8);
+      } else if (window.innerHeight > 580) {
+        setMaxLinesPerPage(7);
+      } else {
+        setMaxLinesPerPage(9);
+      }
+    };
+
+    updateMaxLines();
+    window.addEventListener('resize', updateMaxLines);
+
+    return () => {
+      window.removeEventListener('resize', updateMaxLines);
+    };
   }, []);
 
   const handleFlipLetter = () => {
@@ -99,6 +121,7 @@ const LetterPreviewPage = () => {
               $hasChangeButton={content.length > 0 && images.length > 0}
             >
               <Letter
+                key={`${maxLinesPerPage}`}
                 showType="receive"
                 contentType="all"
                 id={'0'}
@@ -111,6 +134,7 @@ const LetterPreviewPage = () => {
                 height="100%"
                 padding="38px 28px"
                 nameSize="18px"
+                maxLines={maxLinesPerPage}
               />
             </LetterContainer>
             {content.length > 0 && images.length > 0 && (
@@ -206,8 +230,9 @@ const LetterContainer = styled.div<{ $hasChangeButton: boolean }>`
   max-height: 443px;
   margin-bottom: ${({ $hasChangeButton }) => ($hasChangeButton ? '0' : '80px')};
 
-  @media (max-height: 660px) {
+  @media (max-height: 670px) {
     min-height: 350px;
+    max-height: 350px;
   }
 
   @media (max-height: 628px) {

--- a/src/app/store/preview/page.tsx
+++ b/src/app/store/preview/page.tsx
@@ -95,7 +95,9 @@ const LetterPreviewPage = () => {
       <Container>
         <Column>
           <LetterWrapper>
-            <LetterContainer>
+            <LetterContainer
+              $hasChangeButton={content.length > 0 && images.length > 0}
+            >
               <Letter
                 showType="receive"
                 contentType="all"
@@ -195,13 +197,14 @@ const LetterWrapper = styled.div`
   }
 `;
 
-const LetterContainer = styled.div`
+const LetterContainer = styled.div<{ $hasChangeButton: boolean }>`
   display: flex;
   justify-content: center;
   width: 100%;
   max-width: 345px;
-  min-height: 354px;
-  max-height: 354px;
+  min-height: 443px;
+  max-height: 443px;
+  margin-bottom: ${({ $hasChangeButton }) => ($hasChangeButton ? '0' : '80px')};
 
   @media (max-height: 660px) {
     min-height: 350px;
@@ -220,6 +223,8 @@ const LetterContainer = styled.div`
   @media (max-height: 550px) {
     min-height: 280px;
     max-height: 280px;
+    margin-bottom: ${({ $hasChangeButton }) =>
+      $hasChangeButton ? '0' : '55px'};
   }
 `;
 

--- a/src/app/store/template/page.tsx
+++ b/src/app/store/template/page.tsx
@@ -24,6 +24,8 @@ const LetterTemplatePage = () => {
   const { senderName, content, images, templateType } =
     useRecoilValue(registerLetterState);
   const setRegisterLetterState = useSetRecoilState(registerLetterState);
+  const [maxLinesPerPage, setMaxLinesPerPage] = useState(7);
+  const [fontSize, setFontSize] = useState<string>('16px');
 
   const [template, setTemplateType] = useState<number>(
     templateType || ALL_TEMPLATES[0]
@@ -35,6 +37,34 @@ const LetterTemplatePage = () => {
   useEffect(() => {
     setSsrCompleted();
   }, [setSsrCompleted]);
+
+  useEffect(() => {
+    const updateMaxLines = () => {
+      if (window.innerHeight > 725) {
+        setMaxLinesPerPage(8);
+        setFontSize('16px');
+      } else if (window.innerHeight > 628) {
+        setMaxLinesPerPage(7);
+        setFontSize('16px');
+      } else if (window.innerHeight > 580) {
+        setMaxLinesPerPage(6);
+        setFontSize('16px');
+      } else if (window.innerHeight > 550) {
+        setMaxLinesPerPage(5);
+        setFontSize('16px');
+      } else {
+        setMaxLinesPerPage(4);
+        setFontSize('11px');
+      }
+    };
+
+    updateMaxLines();
+    window.addEventListener('resize', updateMaxLines);
+
+    return () => {
+      window.removeEventListener('resize', updateMaxLines);
+    };
+  }, []);
 
   const hanleChangeTemplate = (id: number) => {
     setTemplateType(id);
@@ -66,8 +96,10 @@ const LetterTemplatePage = () => {
           <LetterWrapper>
             <LetterContainer>
               <Letter
+                key={`${maxLinesPerPage}-${fontSize}`}
                 showType="receive"
                 contentType="one"
+                isTemplate={true}
                 id={'0'}
                 templateType={template}
                 name={senderName}
@@ -77,6 +109,8 @@ const LetterTemplatePage = () => {
                 width="100%"
                 height="100%"
                 padding="40px 30px"
+                maxLines={maxLinesPerPage}
+                fontSize={fontSize}
               />
             </LetterContainer>
           </LetterWrapper>

--- a/src/app/store/template/page.tsx
+++ b/src/app/store/template/page.tsx
@@ -66,7 +66,7 @@ const LetterTemplatePage = () => {
           <LetterWrapper>
             <LetterContainer>
               <Letter
-                showType="previewReceive"
+                showType="receive"
                 contentType="one"
                 id={'0'}
                 templateType={template}

--- a/src/app/verify/letter/page.tsx
+++ b/src/app/verify/letter/page.tsx
@@ -1,33 +1,33 @@
-"use client";
+'use client';
 
 import {
   getVerifyedLetter,
   saveVerifyedLetter,
-  verifyLetter,
-} from "@/api/letter/letter";
-import { getMainId } from "@/api/planet/space/space";
-import Button from "@/components/common/Button";
-import Loader, { LoaderContainer } from "@/components/common/Loader";
-import Letter from "@/components/letter/Letter";
-import { LetterType } from "@/types/letter";
-import { getAccessToken } from "@/utils/storage";
-import { useRouter, useSearchParams } from "next/navigation";
-import { Suspense, useEffect, useState } from "react";
-import styled from "styled-components";
+  verifyLetter
+} from '@/api/letter/letter';
+import { getMainId } from '@/api/planet/space/space';
+import Button from '@/components/common/Button';
+import Loader, { LoaderContainer } from '@/components/common/Loader';
+import Letter from '@/components/letter/Letter';
+import { LetterType } from '@/types/letter';
+import { getAccessToken } from '@/utils/storage';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Suspense, useEffect, useState } from 'react';
+import styled from 'styled-components';
 
 const VerifyLetter = () => {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const url = searchParams.get("url");
+  const url = searchParams.get('url');
   const [key, setKey] = useState(1);
-  const [letterId, setletterId] = useState("");
+  const [letterId, setletterId] = useState('');
   const [letterData, setLetterData] = useState<LetterType>();
   const [isImage, setIsImage] = useState(false);
   const accessToken = getAccessToken();
   const [isLoading, setIsLoading] = useState(true);
 
   const handleButtonClick = () => {
-    router.push("/planet");
+    router.push('/planet');
   };
 
   const changeImageorContent = () => {
@@ -45,11 +45,11 @@ const VerifyLetter = () => {
         sender: response.data.senderName,
         content: response.data.content,
         date: response.data.date,
-        images: response.data.images,
+        images: response.data.images
       });
     } catch (error) {
       //검증 완료된 사용자이지만 모종의 이유로 데이터 받아오는 것이 실패한 경우
-      console.error("편지 조회 실패:", error);
+      console.error('편지 조회 실패:', error);
       router.push(`/error/network`);
     }
   };
@@ -59,10 +59,10 @@ const VerifyLetter = () => {
       const response = await saveVerifyedLetter(letterId);
       console.log(response.data.message);
     } catch (error) {
-      console.log("편지 저장 실패: ", error);
-      router.push("/error/network");
+      console.log('편지 저장 실패: ', error);
+      router.push('/error/network');
     }
-    router.push("/planet");
+    router.push('/planet');
   };
 
   useEffect(() => {
@@ -89,16 +89,16 @@ const VerifyLetter = () => {
             .catch((error) => {
               if (error.status === 403) {
                 //해당 사용자가 열람 가능한 편지가 아님
-                console.error("검증 실패:", error);
+                console.error('검증 실패:', error);
                 router.push(`/error/letter`);
               } else {
-                router.push("/error");
+                router.push('/error');
               }
             });
         }
       } catch (error) {
         // 메인 ID 조회 실패 시 로그인 페이지로 이동
-        console.error("유효한 회원이 아닌 것으로 판단:", error);
+        console.error('유효한 회원이 아닌 것으로 판단:', error);
         if (url) {
           router.push(`/login?url=${url}`);
         } else {
@@ -127,7 +127,7 @@ const VerifyLetter = () => {
           <Letter
             showType="url"
             key={key}
-            id={letterId || ""}
+            id={letterId || ''}
             templateType={letterData.templateType}
             name={letterData.sender}
             images={letterData.images}
@@ -139,7 +139,7 @@ const VerifyLetter = () => {
           <Letter
             showType="url"
             key={key}
-            id={letterId || ""}
+            id={letterId || ''}
             templateType={letterData.templateType}
             name={letterData.sender}
             content={letterData.content}
@@ -152,7 +152,7 @@ const VerifyLetter = () => {
           <ChangeButtonWrapper onClick={changeImageorContent}>
             <img src="/assets/icons/ic_change_image.svg"></img>
             <div>
-              클릭하면 {isImage ? "편지 내용" : "사진"}을 확인할 수 있어요!
+              클릭하면 {isImage ? '편지 내용' : '사진'}을 확인할 수 있어요!
             </div>
           </ChangeButtonWrapper>
         ) : (
@@ -201,19 +201,13 @@ const Container = styled.div`
   justify-content: space-between;
   box-sizing: border-box;
   height: 100%;
-  max-height: 852px;
+  height: 100%;
   color: white;
+  overflow-y: auto;
   overflow-x: hidden;
   padding: 40px 0;
   background: ${(props) => props.theme.colors.bg};
-`;
 
-const MainWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  padding: 0 19px 0 24px;
-  overflow-y: auto;
-  overflow-x: hidden;
   &::-webkit-scrollbar {
     width: 5px; /* Width of the scrollbar */
   }
@@ -227,6 +221,14 @@ const MainWrapper = styled.div`
     background: ${(props: any) => props.theme.colors.gray600};
     border-radius: 10px; /* Rounded corners */
   }
+`;
+
+const MainWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 0 19px 0 24px;
+  overflow-x: hidden;
+  padding-bottom: 100px;
 `;
 
 const Header = styled.div`
@@ -249,11 +251,16 @@ const HeaderSubTitle = styled.div`
 `;
 
 const ButtonContainer = styled.div`
+  width: 100%;
+  position: absolute;
+  padding: 0 20px;
+  bottom: 40px;
+  left: 0;
   display: flex;
   flex-direction: row;
-  width: 100%;
   gap: 12px;
   justify-content: center;
+  z-index: 1000;
 `;
 
 const ChangeButtonWrapper = styled.div`

--- a/src/components/letter/Content.tsx
+++ b/src/components/letter/Content.tsx
@@ -3,6 +3,7 @@ import styled, { css } from 'styled-components';
 import { useSwipeable } from 'react-swipeable';
 import { contentType } from './Letter';
 import Image from 'next/image';
+import { theme } from '@/styles/theme';
 
 interface SwipeableContentProps {
   contentType: contentType;
@@ -22,7 +23,9 @@ const SwipeableContent: React.FC<SwipeableContentProps> = ({
   page
 }) => {
   const [isPopupOpen, setPopupOpen] = useState(false);
-  const [popupImage, setPopupImage] = useState('');
+  const [popupPage, setPopupPage] = useState(page);
+
+  /* 스와이프 핸들러 */
   const handlers = useSwipeable({
     onSwipedLeft: () => setPage(page < totalPage - 1 ? page + 1 : page),
     onSwipedRight: () => setPage(page > 0 ? page - 1 : page),
@@ -30,10 +33,21 @@ const SwipeableContent: React.FC<SwipeableContentProps> = ({
     trackMouse: true
   });
 
-  const xOffset = -page * 100;
+  /* 팝업 내 스와이프 핸들러 */
+  const popupHandlers = useSwipeable({
+    onSwipedLeft: () =>
+      setPopupPage(popupPage < totalPage - 1 ? popupPage + 1 : popupPage),
+    onSwipedRight: () =>
+      setPopupPage(popupPage > 0 ? popupPage - 1 : popupPage),
+    trackTouch: true,
+    trackMouse: true
+  });
 
-  const openPopup = (image: string) => {
-    setPopupImage(image);
+  const xOffset = -page * 100;
+  const popupOffset = -popupPage * 100;
+
+  const openPopup = (index: number) => {
+    setPopupPage(index);
     setPopupOpen(true);
   };
 
@@ -42,8 +56,27 @@ const SwipeableContent: React.FC<SwipeableContentProps> = ({
   return (
     <SwipeableContainer {...handlers}>
       {isPopupOpen && (
-        <PopupOverlay onClick={closePopup}>
-          <PopupImage src={popupImage} onClick={(e) => e.stopPropagation()} />
+        <PopupOverlay {...popupHandlers}>
+          <PopupTop>
+            <PopupPage>
+              {totalPage > 1 && (
+                <span>
+                  {popupPage + 1} / {totalPage}
+                </span>
+              )}
+            </PopupPage>
+            <PopupCloseButton onClick={closePopup}>
+              <img src="/assets/icons/ic_cancel.svg" width={24} height={24} />
+            </PopupCloseButton>
+          </PopupTop>
+          {/* 팝업 이미지 슬라이더*/}
+          <PopupImageSlider
+            style={{ transform: `translateX(${popupOffset}%)` }}
+          >
+            {content.map((imgSrc, index) => (
+              <PopupImage key={index} src={imgSrc} draggable="false" />
+            ))}
+          </PopupImageSlider>
         </PopupOverlay>
       )}
       <ContentSlider style={{ transform: `translateX(${xOffset}%)` }}>
@@ -52,8 +85,7 @@ const SwipeableContent: React.FC<SwipeableContentProps> = ({
             {isImage ? (
               <ImageContainerWrapper>
                 <ImageContainer src={content[0]} alt="image" fill />
-                <PopupBtn onClick={() => openPopup(content[0])}>
-                  {' '}
+                <PopupBtn onClick={() => openPopup(0)}>
                   <img src="/assets/icons/ic_search.svg" />
                 </PopupBtn>
               </ImageContainerWrapper>
@@ -66,9 +98,13 @@ const SwipeableContent: React.FC<SwipeableContentProps> = ({
             <ContentItem key={index} $isImage={isImage}>
               {isImage ? (
                 <ImageContainerWrapper>
-                  {/* <ImageContainer src={content[index]} /> */}
-                  <ImageContainer src={content[0]} alt="image" fill />
-                  <PopupBtn onClick={() => openPopup(content[index])}>
+                  <ImageContainer
+                    src={content[index]}
+                    alt="image"
+                    fill
+                    draggable="false"
+                  />
+                  <PopupBtn onClick={() => openPopup(index)}>
                     <img src="/assets/icons/ic_search.svg" />
                   </PopupBtn>
                 </ImageContainerWrapper>
@@ -173,16 +209,46 @@ const PopupOverlay = styled.div`
   height: 100%;
   background: rgba(0, 0, 0, 0.8);
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
+  gap: 10px;
   z-index: 99999;
+  overflow: hidden;
+`;
+
+const PopupTop = styled.div`
+  width: 100%;
+  padding: 0 24px;
+  display: flex;
+  justify-content: space-between;
+  position: fixed;
+  top: 53px;
+  z-index: 10;
+`;
+
+const PopupPage = styled.div`
+  color: ${theme.colors.white};
+  ${theme.fonts.body09};
+`;
+
+const PopupCloseButton = styled.button`
+  width: 24px;
+  height: 24px;
+`;
+
+const PopupImageSlider = styled.div`
+  display: flex;
+  width: 100%;
+  height: 100%;
+  transition: transform 0.5s ease-out;
 `;
 
 const PopupImage = styled.img`
-  max-width: 90%;
-  max-height: 90%;
+  width: 100%;
+  max-width: 393px;
+  height: 100%;
   object-fit: contain;
-  border-radius: 10px;
 `;
 
 const PopupBtn = styled.button`

--- a/src/components/letter/Content.tsx
+++ b/src/components/letter/Content.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import styled, { css } from 'styled-components';
 import { useSwipeable } from 'react-swipeable';
 import { contentType } from './Letter';
@@ -24,6 +24,20 @@ const SwipeableContent: React.FC<SwipeableContentProps> = ({
 }) => {
   const [isPopupOpen, setPopupOpen] = useState(false);
   const [popupPage, setPopupPage] = useState(page);
+  const [minWidth, setMinWidth] = useState(393);
+
+  useEffect(() => {
+    const updateWidth = () => {
+      setMinWidth(window.innerWidth || 393);
+    };
+
+    updateWidth();
+    window.addEventListener('resize', updateWidth);
+
+    return () => {
+      window.removeEventListener('resize', updateWidth);
+    };
+  }, []);
 
   /* 스와이프 핸들러 */
   const handlers = useSwipeable({
@@ -74,7 +88,12 @@ const SwipeableContent: React.FC<SwipeableContentProps> = ({
             style={{ transform: `translateX(${popupOffset}%)` }}
           >
             {content.map((imgSrc, index) => (
-              <PopupImage key={index} src={imgSrc} draggable="false" />
+              <PopupImage
+                key={index}
+                src={imgSrc}
+                draggable="false"
+                $minWidth={minWidth}
+              />
             ))}
           </PopupImageSlider>
         </PopupOverlay>
@@ -244,9 +263,9 @@ const PopupImageSlider = styled.div`
   transition: transform 0.5s ease-out;
 `;
 
-const PopupImage = styled.img`
+const PopupImage = styled.img<{ $minWidth: number }>`
   width: 100%;
-  max-width: 393px;
+  min-width: ${({ $minWidth }) => `${$minWidth < 393 ? $minWidth : 393}px`};
   height: 100%;
   object-fit: contain;
 `;

--- a/src/components/letter/Content.tsx
+++ b/src/components/letter/Content.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import styled, { css } from 'styled-components';
 import { useSwipeable } from 'react-swipeable';
 import { contentType } from './Letter';
+import Image from 'next/image';
 
 interface SwipeableContentProps {
   contentType: contentType;
@@ -50,8 +51,11 @@ const SwipeableContent: React.FC<SwipeableContentProps> = ({
           <ContentItem $isImage={isImage}>
             {isImage ? (
               <ImageContainerWrapper>
-                <ImageContainer src={content[0]}></ImageContainer>
-                <PopupBtn onClick={() => openPopup(content[0])}>Open</PopupBtn>
+                <ImageContainer src={content[0]} alt="image" fill />
+                <PopupBtn onClick={() => openPopup(content[0])}>
+                  {' '}
+                  <img src="/assets/icons/ic_search.svg" />
+                </PopupBtn>
               </ImageContainerWrapper>
             ) : (
               <ClampedText $contentType={contentType}>{content}</ClampedText>
@@ -62,9 +66,10 @@ const SwipeableContent: React.FC<SwipeableContentProps> = ({
             <ContentItem key={index} $isImage={isImage}>
               {isImage ? (
                 <ImageContainerWrapper>
-                  <ImageContainer src={content[index]} />
+                  {/* <ImageContainer src={content[index]} /> */}
+                  <ImageContainer src={content[0]} alt="image" fill />
                   <PopupBtn onClick={() => openPopup(content[index])}>
-                    <img src="/assets/icons/ic_search.svg"></img>
+                    <img src="/assets/icons/ic_search.svg" />
                   </PopupBtn>
                 </ImageContainerWrapper>
               ) : (
@@ -83,21 +88,26 @@ export default SwipeableContent;
 const SwipeableContainer = styled.div`
   overflow: hidden;
   width: 100%;
-  height: auto;
+  height: 100%;
   box-sizing: border-box;
   border-radius: 10px;
+  position: relative;
+
   @media (max-width: 375px) {
     max-height: 235px;
   }
 `;
 
 const ContentSlider = styled.div`
+  width: 100%;
+  height: 100%;
   display: flex;
   transition: transform 0.5s ease-out;
 `;
 
 const ContentItem = styled.div<{ $isImage: boolean }>`
   width: 100%;
+  height: 100%;
   flex-shrink: 0;
   display: flex;
   overflow: hidden;
@@ -115,16 +125,12 @@ const ImageContainerWrapper = styled.div`
   height: 100%;
 `;
 
-const ImageContainer = styled.div<{ src: string }>`
+const ImageContainer = styled(Image)`
   width: 100%;
-  height: 100%; /* 부모 컨테이너에 맞추어 높이를 조정 */
-  min-height: 200px;
-  max-height: 300px;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 10px;
   overflow: hidden;
-  background-image: url(${(props) => props.src});
-  background-size: cover; /* 이미지를 부모 컨테이너에 맞추고 초과된 부분을 크롭 */
-  background-position: center; /* 이미지의 가운데를 표시 */
-  background-repeat: no-repeat;
 
   -webkit-user-select: none;
   -khtml-user-select: none;

--- a/src/components/letter/Content.tsx
+++ b/src/components/letter/Content.tsx
@@ -12,6 +12,7 @@ interface SwipeableContentProps {
   totalPage: number;
   isImage: boolean;
   page: number;
+  maxLines?: number;
 }
 
 const SwipeableContent: React.FC<SwipeableContentProps> = ({
@@ -20,13 +21,15 @@ const SwipeableContent: React.FC<SwipeableContentProps> = ({
   setPage,
   totalPage,
   isImage,
-  page
+  page,
+  maxLines
 }) => {
   const [isPopupOpen, setPopupOpen] = useState(false);
   const [popupPage, setPopupPage] = useState(page);
   const [minWidth, setMinWidth] = useState(393);
 
   useEffect(() => {
+    console.log('maxLines', maxLines);
     const updateWidth = () => {
       setMinWidth(window.innerWidth || 393);
     };
@@ -109,7 +112,9 @@ const SwipeableContent: React.FC<SwipeableContentProps> = ({
                 </PopupBtn>
               </ImageContainerWrapper>
             ) : (
-              <ClampedText $contentType={contentType}>{content}</ClampedText>
+              <ClampedText $contentType={contentType} $maxLines={maxLines}>
+                {content[0]}
+              </ClampedText>
             )}
           </ContentItem>
         ) : (
@@ -128,7 +133,9 @@ const SwipeableContent: React.FC<SwipeableContentProps> = ({
                   </PopupBtn>
                 </ImageContainerWrapper>
               ) : (
-                <ClampedText $contentType={contentType}>{item}</ClampedText>
+                <ClampedText $contentType={contentType} $maxLines={maxLines}>
+                  {item}
+                </ClampedText>
               )}
             </ContentItem>
           ))
@@ -166,12 +173,6 @@ const ContentItem = styled.div<{ $isImage: boolean }>`
   flex-shrink: 0;
   display: flex;
   overflow: hidden;
-  align-items: center;
-  ${($isImage) =>
-    $isImage &&
-    css`
-      overflow: hidden;
-    `}
 `;
 
 const ImageContainerWrapper = styled.div`
@@ -198,16 +199,19 @@ const ImageContainer = styled(Image)`
   -o-user-drag: none;
 `;
 
-const ClampedText = styled.div<{ $contentType: contentType }>`
+const ClampedText = styled.div<{
+  $contentType: contentType;
+  $maxLines: number;
+}>`
   width: 100%;
   display: -webkit-box;
   -webkit-box-orient: vertical;
   overflow: hidden;
 
-  ${({ $contentType }) =>
+  ${({ $contentType, $maxLines }) =>
     $contentType === 'one'
       ? css`
-          -webkit-line-clamp: 7;
+          -webkit-line-clamp: ${$maxLines || 7};
           text-overflow: ellipsis;
         `
       : css`

--- a/src/components/letter/Letter.tsx
+++ b/src/components/letter/Letter.tsx
@@ -20,6 +20,7 @@ type pageType = 'independent' | 'space';
 interface LetterProps {
   showType: showType;
   contentType?: contentType;
+  isTemplate?: boolean;
   pageType?: pageType;
   id: string;
   templateType: number;
@@ -33,14 +34,16 @@ interface LetterProps {
   padding?: string;
   readOnly?: boolean;
   nextLetterId?: string;
-  maxLineWidth?: number;
+  maxLines?: number;
   nameSize?: string;
+  fontSize?: string;
 }
 
 const Letter = (props: LetterProps) => {
   const {
     showType,
     contentType = 'all',
+    isTemplate = false,
     pageType = 'independent',
     id,
     templateType,
@@ -54,7 +57,9 @@ const Letter = (props: LetterProps) => {
     padding,
     readOnly = false,
     nextLetterId,
-    nameSize
+    maxLines,
+    nameSize,
+    fontSize // 줄넘김 인식을 위한 폰트 사이즈 지정 (ex. "11px")
   } = props;
   const router = useRouter();
   const [currentPage, setCurrentPage] = useState(0);
@@ -89,14 +94,20 @@ const Letter = (props: LetterProps) => {
       const container = document.querySelector('.ContentContainer'); // content 부모 컨테이너
       if (!container) return;
 
-      const maxLinesPerPage = contentType === 'one' ? 7 : 12;
+      const maxLinesPerPage = isTemplate
+        ? maxLines + 2
+        : maxLines
+        ? maxLines
+        : contentType === 'one'
+        ? 7
+        : 12;
 
       const canvas = document.createElement('canvas');
       const context = canvas.getContext('2d');
 
       if (context) {
         canvas.width = container.clientWidth; // 부모 컨테이너의 width 기준
-        context.font = '16px Pretendard';
+        context.font = `${fontSize ? fontSize : '16px'} Pretendard`;
         const maxWidth = container.clientWidth;
 
         let currentLine = '';
@@ -217,9 +228,9 @@ const Letter = (props: LetterProps) => {
       )}
       {showType === 'send' && <Date>{date}</Date>}
       <Content
-        $showType={showType}
+        key={`${maxLines}`}
+        $isTemplate={isTemplate}
         $contentType={contentType}
-        $isImage={isImage}
         className="ContentContainer"
       >
         <SwipeableContent
@@ -229,6 +240,7 @@ const Letter = (props: LetterProps) => {
           totalPage={totalPage ? (totalPage >= 8 ? 8 : totalPage) : 0}
           isImage={isChangeImage}
           page={currentPage}
+          maxLines={maxLines}
         />
       </Content>
       {showType === 'url' && (
@@ -326,9 +338,8 @@ const Date = styled.div`
 `;
 
 const Content = styled.div<{
-  $showType: string;
+  $isTemplate: boolean;
   $contentType: string;
-  $isImage: boolean;
 }>`
   width: 100%;
   height: 100%;
@@ -339,9 +350,7 @@ const Content = styled.div<{
   box-sizing: border-box;
   padding: 10px 0;
   ${(props) =>
-    (props.$showType === 'previewSend' ||
-      props.$showType === 'previewReceive') &&
-    props.$contentType === 'one'
+    props.$isTemplate && props.$contentType === 'one'
       ? props.theme.fonts.caption09
       : props.theme.fonts.body07};
   -webkit-user-select: none;

--- a/src/components/letter/Letter.tsx
+++ b/src/components/letter/Letter.tsx
@@ -1,4 +1,4 @@
-import React, { use, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import styled, { css } from 'styled-components';
 import Pagination from './Pagination';
 import SwipeableContent from './Content';
@@ -237,15 +237,14 @@ const Letter = (props: LetterProps) => {
           <UrlDate>{date}</UrlDate>
         </UrlWrapper>
       )}
-      {contentType === 'all' &&
-        (totalPage > 1 ? (
+      <PaginationDiv>
+        {contentType === 'all' && totalPage > 1 && (
           <Pagination
             currentPage={currentPage}
             totalPage={totalPage ? (totalPage >= 8 ? 8 : totalPage) : 0}
           />
-        ) : (
-          <PaginationDiv />
-        ))}
+        )}
+      </PaginationDiv>
     </Container>
   );
 };
@@ -263,7 +262,7 @@ const Container = styled.div<{
   justify-content: space-between;
   box-sizing: border-box;
   width: 100%;
-  height: auto;
+  height: 100%;
   padding: ${({ $padding }) => ($padding ? $padding : '34px')};
   max-width: ${({ $width }) => ($width ? $width : '345px')};
   max-height: ${({ $height }) => ($height ? $height : '349px')};
@@ -297,14 +296,6 @@ const TopContainer = styled.div<{
   }
 `;
 
-const TopPreviewContainer = styled(TopContainer)`
-  ${theme.fonts.subtitle}
-
-  @media (max-height: 628px) {
-    margin-top: 0;
-  }
-`;
-
 const Name = styled.div<{
   $nameSize?: string;
 }>`
@@ -312,6 +303,7 @@ const Name = styled.div<{
   align-items: center;
   text-align: center;
   ${(props) => props.theme.fonts.subtitle};
+  margin-bottom: 10px;
 
   @media (max-height: 628px) {
     ${(props) => props.theme.fonts.body7};
@@ -339,11 +331,7 @@ const Content = styled.div<{
   $isImage: boolean;
 }>`
   width: 100%;
-  /* ${(props) =>
-    props.$showType === 'previewSend' || props.$showType === 'previewReceive'
-      ? // ? `flex: 1; height: calc(100% - 80px);`
-        `height: 100%;`
-      : `height: 90%;`} */
+  height: 100%;
   display: flex;
   justify-content: flex-start;
   align-items: center;
@@ -419,7 +407,7 @@ const EditBtn = styled.button`
   ${(props: any) => props.theme.fonts.button01};
   color: ${(props: any) => props.theme.colors.white};
   padding: 10px;
-  border-bottom: 1px solid #5b5f70;
+  border-bottom: 1px solid ${theme.colors.gray500};
 
   @media (max-height: 628px) {
     padding: 5px;
@@ -467,5 +455,9 @@ const UrlDate = styled.div`
 `;
 
 const PaginationDiv = styled.div`
-  height: 16px;
+  height: 6px;
+  position: absolute;
+  bottom: 23px;
+  left: 50%;
+  transform: translateX(-50%);
 `;

--- a/src/components/letter/Letter.tsx
+++ b/src/components/letter/Letter.tsx
@@ -11,7 +11,9 @@ import { registerLetterState } from '@/recoil/letterStore';
 import { flipAnimation } from '@/styles/animation';
 import { useToast } from '@/hooks/useToast';
 
-type showType = 'previewSend' | 'previewReceive' | 'receive' | 'send' | 'url';
+// showType: "편지 보내기" | "편지 보관하기" | "편지 열람" | "보낸 편지 조회" | "카톡으로 접근한 편지 조회"
+// type showType = 'previewSend' | 'previewReceive' | 'receive' | 'send' | 'url';
+type showType = 'receive' | 'send' | 'url';
 export type contentType = 'one' | 'all';
 type pageType = 'independent' | 'space';
 
@@ -187,7 +189,6 @@ const Letter = (props: LetterProps) => {
       $width={width}
       $height={height}
       $padding={padding}
-      $showType={showType}
       className={flip ? 'flip' : ''}
     >
       {isDelete && (
@@ -208,34 +209,13 @@ const Letter = (props: LetterProps) => {
       {(showType === 'receive' || showType === 'send') && (
         <>
           <TopContainer $contentType={contentType}>
-            <Name
-              $showType={showType}
-              $contentType={contentType}
-              $nameSize={nameSize}
-            >
+            <Name $nameSize={nameSize}>
               {`${showType === 'send' ? `To. ` : `From. `} ${name}`}
             </Name>
           </TopContainer>
         </>
       )}
-      {(showType === 'send' || (showType === 'previewSend' && isImage)) && (
-        <Date $showType="send">{date}</Date>
-      )}
-      {(showType === 'previewReceive' || showType === 'previewSend') && (
-        <>
-          <TopPreviewContainer $contentType={contentType}>
-            {name && (
-              <Name
-                $showType={showType}
-                $contentType={contentType}
-                $nameSize={nameSize}
-              >
-                {`${showType === 'previewSend' ? `To. ` : `From. `} ${name}`}
-              </Name>
-            )}
-          </TopPreviewContainer>
-        </>
-      )}
+      {showType === 'send' && <Date>{date}</Date>}
       <Content
         $showType={showType}
         $contentType={contentType}
@@ -277,7 +257,6 @@ const Container = styled.div<{
   $width?: string;
   $height?: string;
   $padding?: string;
-  $showType: 'previewSend' | 'previewReceive' | 'receive' | 'send' | 'url';
 }>`
   display: flex;
   flex-direction: column;
@@ -327,8 +306,6 @@ const TopPreviewContainer = styled(TopContainer)`
 `;
 
 const Name = styled.div<{
-  $showType: string;
-  $contentType: string;
   $nameSize?: string;
 }>`
   display: flex;
@@ -351,10 +328,9 @@ const Name = styled.div<{
     `}
 `;
 
-const Date = styled.div<{ $showType: string }>`
+const Date = styled.div`
   color: ${theme.colors.gray400};
-  ${(props) => props.theme.fonts.body09};
-  ${(props) => (props.$showType === 'send' ? props.theme.fonts.caption03 : '')};
+  ${theme.fonts.caption03};
 `;
 
 const Content = styled.div<{
@@ -363,10 +339,11 @@ const Content = styled.div<{
   $isImage: boolean;
 }>`
   width: 100%;
-  ${(props) =>
+  /* ${(props) =>
     props.$showType === 'previewSend' || props.$showType === 'previewReceive'
-      ? `flex: 1; height: calc(100% - 80px);`
-      : `height: 90%;`}
+      ? // ? `flex: 1; height: calc(100% - 80px);`
+        `height: 100%;`
+      : `height: 90%;`} */
   display: flex;
   justify-content: flex-start;
   align-items: center;

--- a/src/components/letter/Pagination.tsx
+++ b/src/components/letter/Pagination.tsx
@@ -1,7 +1,7 @@
-import { theme } from "@/styles/theme";
-import React from "react";
-import styled from "styled-components";
-import { motion } from "framer-motion";
+import { theme } from '@/styles/theme';
+import React from 'react';
+import styled from 'styled-components';
+import { motion } from 'framer-motion';
 
 interface PaginationProps {
   currentPage: number;
@@ -35,7 +35,6 @@ const Wrapper = styled.div`
   justify-content: center;
   gap: 4px;
   color: ${theme.colors.gray400};
-  padding-top: 10px;
 `;
 
 const PaginationWrapper = styled.div`
@@ -48,9 +47,9 @@ const PaginationWrapper = styled.div`
 const Circle = styled(motion.div)<{ $isActive: boolean }>`
   width: 6px;
   height: 6px;
-  border-radius: ${({ $isActive }) => ($isActive ? "174px" : "50%")};
+  border-radius: ${({ $isActive }) => ($isActive ? '174px' : '50%')};
   background-color: ${({ $isActive }) =>
     $isActive ? theme.colors.white : theme.colors.gray500};
-  width: ${({ $isActive }) => ($isActive ? "16px" : "6px")}; 
+  width: ${({ $isActive }) => ($isActive ? '16px' : '6px')};
   margin: 0 3px;
 `;


### PR DESCRIPTION
## 연관 이슈

close #139

<br/>

## 개요

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요. -->
편지 관련 QA

<br/>

## ✅ 작업 내용

- [x] 편지 사이즈 조정 (본문 길이에 따라 편지지 크기가 다름)
- [x] 사진이 편지지 크기를 벗어나는 오류 수정
- [x] 모바일 사파리 돋보기 이미지 오류 수정 (사진만 있는 경우에 오류 발생)
- [x] 편지 내용 길어질 때 From과 겹치는 오류
- [x] 원본 사진 확대 및 여러 장 보기 스와이프 구현
- [x] 확대 원본 사이즈 늘리기
- [x] 사진 이미지 압축 조정
<hr/>

- [x] `Letter.tsx` 및 `Content.tsx` 리팩토링
- [x] 편지지 줄넘김 및 페이지 내 최대 라인 수 브라우저 크기별 설정 (반응형 작업)

<br/>

## 🖥 구현 결과

<!--  구현한 기능이 보이는 스크린샷을 업로드해주세요. -->

https://github.com/user-attachments/assets/060bf42d-f07c-4b56-8859-b6b69b5576e5


<br/>

### 📝 기타 사항

<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업 등을 적어주세요. -->
- `Letter.tsx` 컴포넌트에서 contentType이 명확하게 와닿지 않고 불필요한 타입들을 정리할 수 있을 것 같아 리팩토링 했습니다! From, To에 따라 receiver, send로 분리하고 verify 경로로 들어가는 것만 이름, 날짜 등 정보가 하단에 되어있어 추가로 url 까지 3가지만 남겼어요. 그리고 기존에 previewSend나 previewReceive로 받아왔는데 이걸 없애고 `/template` 경로에서 구분해야하는 것들만 isTemplate으로 받아오게 했습니다.
- 편지지 줄넘김 반응형을 하려면 폰트 사이즈에 따라서도 줄넘김 지점이 달라지고, 컴포넌트 크기에 따라서 몇 줄까지 보여줄지가 달라서 이를 Letter 컴포넌트를 사용하는 페이지에서 상태값으로 관리해 props로 넘겨주도록 했습니다. (`fontSize`와 `maxLines`) `verify` 페이지 외에는 반응형 다 확인했어요! 혹시 제가 놓친 부분 있다면 알려주세요😃
- 임시저장할 때 편지 길이를 길게 하니 500 에러가 있었어요. 사진 4장 + 300자는 괜찮았는데, 사진 4장 + 500자 정도면 오류가 나는 걸로 보아 용량 혹은 길이 관련 이슈 같은데, 해당 내용은 백엔드에게 전달 후 다시 보겠습니다!
<br/>

### 리뷰 요구사항

<!-- 리뷰 시에 유심히 봐주었으면 하는 부분이 있다면 설명해주세요. -->
- 편지지 반응형에서 줄넘김 및 페이지네이션을 이렇게 일일히.. 설정하는 방법밖에 없을지 고민입니다. 아무래도 하나하나 일일히 브라우저 움직이면서 페이지마다 설정해야하니 불편한 것 같아서요.
<br/>
