### PR TITLE
[Feat] 구글 로그인

### DIFF
--- a/src/app/login/auth/page.tsx
+++ b/src/app/login/auth/page.tsx
@@ -17,9 +17,12 @@ const Auth = () => {
   const [absoluteUrl, setAbsoluteUrl] = useState('');
   const [storeUrl, setstoreUrl] = useState('');
   const [type, setType] = useState('');
+  const [oauthAccessToken, setOauthAccessToken] = useState('');
+  const [provider, setProvider] = useState('');
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
+      //oauth 타입을 state에 저장
       const params = new URL(window.location.href).searchParams;
       const typeParam = params.get('type');
       setType(typeParam);
@@ -31,29 +34,72 @@ const Auth = () => {
   }, []);
 
   useEffect(() => {
-    if (!absoluteUrl) {
-      return;
-    }
+    if (!absoluteUrl || !type) return;
     const getToken = async () => {
       const AUTHORIZATION_CODE = new URL(window.location.href).searchParams.get(
         'code'
       );
+
       const TYPE = new URL(window.location.href).searchParams.get('type');
 
       let tokenUrl = '';
-      let provider: 'KAKAO' | 'GOOGLE' | 'NAVER';
 
       if (!AUTHORIZATION_CODE || !TYPE) {
         console.error('Authorization Code or Type is missing');
         return;
       }
 
+      //type에 따라 다른 토큰 url 지정
       switch (TYPE) {
         case 'kakao':
-          tokenUrl = `https://kauth.kakao.com/oauth/token?grant_type=authorization_code&client_id=${REST_API_KEY}&redirect_uri=${absoluteUrl}&code=${AUTHORIZATION_CODE}`;
-          provider = 'KAKAO';
+          setProvider('KAKAO');
+          try {
+            const response = await axios.post(
+              'https://kauth.kakao.com/oauth/token',
+              new URLSearchParams({
+                grant_type: 'authorization_code',
+                client_id: REST_API_KEY,
+                redirect_uri: absoluteUrl,
+                code: AUTHORIZATION_CODE
+              }),
+              {
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
+              }
+            );
+            setOauthAccessToken(response.data.access_token);
+          } catch (error) {
+            console.error(error);
+            clearLetterUrl();
+            return;
+          }
+
           break;
         case 'google':
+          setProvider('GOOGLE');
+          try {
+            const body = new URLSearchParams({
+              grant_type: 'authorization_code',
+              client_id: process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID!,
+              client_secret: process.env.NEXT_PUBLIC_GOOGLE_CLIENT_SECRET!,
+              redirect_uri: absoluteUrl,
+              code: AUTHORIZATION_CODE
+            });
+
+            const response = await axios.post(
+              'https://oauth2.googleapis.com/token',
+              body.toString(),
+              {
+                headers: {
+                  'Content-Type': 'application/x-www-form-urlencoded'
+                }
+              }
+            );
+            setOauthAccessToken(response.data.access_token);
+          } catch (error) {
+            console.error('Unsupported OAuth type:', type);
+            clearLetterUrl();
+            return;
+          }
           break;
         case 'naver':
           break;
@@ -61,49 +107,46 @@ const Auth = () => {
           console.error('Unknown OAuth type:', TYPE);
           return;
       }
-
-      try {
-        const response = await axios.post(tokenUrl, {
-          headers: { 'Content-Type': 'application/json' }
-        });
-
-        const oauthAccessToken = response.data.access_token;
-
-        if (oauthAccessToken) {
-          login(provider, oauthAccessToken)
-            .then((res) => {
-              console.log('accessToken', res.data.accessToken);
-              setTokens(res.data.accessToken, res.data.refreshToken);
-              /* 온보딩 여부 저장 */
-              setOnboarding(res.data.isProcessedOnboarding);
-              if (storeUrl) {
-                router.push(`/verify/letter?url=${storeUrl}`);
-                clearLetterUrl();
-              } else {
-                router.push('/planet');
-              }
-            })
-            .catch((error) => {
-              if (error.response && error.response.status === 401) {
-                console.log('registerToken', error.response.data.registerToken);
-                setRegisterToken(error.response.data.registerToken);
-                if (storeUrl) {
-                  router.push(`/signup/step1?url=${storeUrl}`);
-                  clearLetterUrl();
-                } else {
-                  router.push('/signup/step1');
-                }
-              }
-            });
-        }
-      } catch (error) {
-        console.error(error);
-        clearLetterUrl();
-        return;
-      }
     };
     getToken();
-  }, [absoluteUrl]);
+  }, [absoluteUrl, type]);
+
+  useEffect(() => {
+    try {
+      if (oauthAccessToken) {
+        login(provider, oauthAccessToken)
+          .then((res) => {
+            console.log('accessToken', res.data.accessToken);
+            setTokens(res.data.accessToken, res.data.refreshToken);
+            /* 온보딩 여부 저장 */
+            setOnboarding(res.data.isProcessedOnboarding);
+            if (storeUrl) {
+              router.push(`/verify/letter?url=${storeUrl}`);
+              clearLetterUrl();
+            } else {
+              router.push('/planet');
+            }
+          })
+          .catch((error) => {
+            if (error.response && error.response.status === 401) {
+              console.log('registerToken', error.response.data.registerToken);
+              setRegisterToken(error.response.data.registerToken);
+              if (storeUrl) {
+                router.push(`/signup/step1?url=${storeUrl}`);
+                clearLetterUrl();
+              } else {
+                router.push('/signup/step1');
+              }
+            }
+          });
+      }
+    } catch (error) {
+      console.log('oauth token 에러');
+      console.error(error);
+      clearLetterUrl();
+      return;
+    }
+  }, [oauthAccessToken]);
 
   return (
     <Container>

--- a/src/app/login/auth/page.tsx
+++ b/src/app/login/auth/page.tsx
@@ -42,8 +42,6 @@ const Auth = () => {
 
       const TYPE = new URL(window.location.href).searchParams.get('type');
 
-      let tokenUrl = '';
-
       if (!AUTHORIZATION_CODE || !TYPE) {
         console.error('Authorization Code or Type is missing');
         return;

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -10,6 +10,10 @@ interface OauthButtonProps {
   bgColor: string;
 }
 
+const notReady = () => {
+  alert('준비 중입니다.');
+};
+
 export default function Login() {
   return (
     <Container>
@@ -24,6 +28,7 @@ export default function Login() {
               alt="Naver"
               width={26}
               height={26}
+              onClick={notReady}
             />
           </OauthButton>
           <OauthButton bgColor="#FFFFFF">
@@ -33,7 +38,9 @@ export default function Login() {
             <SocialKakao />
           </OauthButton>
         </OauthWrapper>
-        <LetterBtnText>로그인 없이 편지 작성해보기</LetterBtnText>
+        <LetterBtnText onClick={notReady}>
+          로그인 없이 편지 작성해보기
+        </LetterBtnText>
       </ImageWrapper>
     </Container>
   );

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -14,6 +14,32 @@ const notReady = () => {
   alert('준비 중입니다.');
 };
 
+const oauthButtons = [
+  {
+    key: 'naver',
+    bgColor: '#03CF5D',
+    component: (
+      <Image
+        src="/assets/icons/ic_naver.svg"
+        alt="Naver"
+        width={26}
+        height={26}
+        onClick={() => alert('준비 중입니다.')}
+      />
+    )
+  },
+  {
+    key: 'google',
+    bgColor: '#FFFFFF',
+    component: <SocialGoogle />
+  },
+  {
+    key: 'kakao',
+    bgColor: '#FEE500',
+    component: <SocialKakao />
+  }
+];
+
 export default function Login() {
   return (
     <Container>
@@ -22,21 +48,11 @@ export default function Login() {
         <LogoText>편지로 수놓는 나의 스페이스</LogoText>
         <LogoImage src="/assets/login/login_logo.png" />
         <OauthWrapper>
-          <OauthButton bgColor="#03CF5D">
-            <Image
-              src="/assets/icons/ic_naver.svg"
-              alt="Naver"
-              width={26}
-              height={26}
-              onClick={notReady}
-            />
-          </OauthButton>
-          <OauthButton bgColor="#FFFFFF">
-            <SocialGoogle />
-          </OauthButton>
-          <OauthButton bgColor="#FEE500">
-            <SocialKakao />
-          </OauthButton>
+          {oauthButtons.map(({ key, bgColor, component }) => (
+            <OauthButton key={key} bgColor={bgColor}>
+              {component}
+            </OauthButton>
+          ))}
         </OauthWrapper>
         <LetterBtnText onClick={notReady}>
           로그인 없이 편지 작성해보기

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -17,6 +17,8 @@ const MyPage = () => {
   const [email, setEmail] = useState('');
   const [planetCount, setPlanetCount] = useState(0);
   const [letterCount, setLetterCount] = useState(0);
+  const [platform, setPlatform] = useState('');
+
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -62,7 +64,8 @@ const MyPage = () => {
       const response = await getUserInfo();
       setName(response.data.name);
       setEmail(response.data.email);
-      console.log('회원정보 조회 성공:', response.data);
+      setPlatform(response.data.socialPlatform);
+      // console.log('회원정보 조회 성공:', response.data);
     } catch (error) {
       console.error('회원정보 조회 실패:', error);
     }
@@ -75,6 +78,19 @@ const MyPage = () => {
       setPlanetCount(response.data.spaceCount);
     } catch (error) {
       console.error('편지수, 행성수 조회 실패:', error);
+    }
+  };
+
+  const EmailType = (platform): string => {
+    switch (platform) {
+      case 'GOOGLE':
+        return '/assets/icons/ic_google.svg';
+      case 'KAKAO':
+        return '/assets/icons/ic_kakao_profile.svg';
+      case 'NAVER':
+        return '/assets/icons/ic_naver.svg';
+      default:
+        return '';
     }
   };
 
@@ -96,7 +112,11 @@ const MyPage = () => {
                 <ProfileInfo>
                   <ProfileName>{name}님의 스페이스</ProfileName>
                   <ProfileEmail>
-                    <img src="/assets/icons/ic_kakao_profile.svg" />
+                    <StyledIcon
+                      src={EmailType(platform)}
+                      alt="emailIcon"
+                      platform={platform as keyof typeof iconSizes}
+                    />
                     <div>{email}</div>
                   </ProfileEmail>
                   <CountRaw>
@@ -240,6 +260,17 @@ const ProfileImage = styled.img`
   @media (max-width: 370px) {
     width: 100px;
   }
+`;
+
+const iconSizes = {
+  GOOGLE: 20,
+  KAKAO: 20,
+  NAVER: 20
+} as const;
+
+const StyledIcon = styled.img<{ platform: keyof typeof iconSizes }>`
+  width: ${({ platform }) => iconSizes[platform]}px;
+  height: ${({ platform }) => iconSizes[platform]}px;
 `;
 
 const ProfileInfo = styled.div`

--- a/src/components/signup/SocialGoogle.tsx
+++ b/src/components/signup/SocialGoogle.tsx
@@ -8,33 +8,36 @@ import Loader, { LoaderContainer } from '../common/Loader';
 const SocialGoogle = () => {
   const searchParams = useSearchParams();
   const url = searchParams.get('url');
-  const REST_API_KEY = process.env.NEXT_PUBLIC_REST_API_KEY;
-  const GOOGLE_URL = '/login/google';
   const [absoluteUrl, setabsoluteUrl] = useState('');
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
       setabsoluteUrl(
-        window.location.protocol + '//' + window.location.host + '/login/kakao'
+        window.location.protocol +
+          '//' +
+          window.location.host +
+          '/login/auth?type=google'
       );
     }
   }, []);
 
   const handleLogin = () => {
-    //이때 localStorage에 저장된 accessToken이 만료되었는지 확인해야함.
-    // if (accessToken) {
-    //   if (url) {
-    //     router.push(`/verify?url=${url}`);
-    //   } else {
-    //     router.push("/");
-    //   }
-    //   setAccessToken(accessToken);
-    // } else {
-    //받은 편지를 통해 들어올 경우 url를 저장한다.
     if (url) {
       setLetterUrl(url);
     }
-    window.location.href = GOOGLE_URL;
+    const GOOGLE_CLIENT_ID = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID;
+    const scope = 'openid profile email';
+
+    const authUrl = [
+      'https://accounts.google.com/o/oauth2/v2/auth',
+      `?client_id=${GOOGLE_CLIENT_ID}`,
+      `&redirect_uri=${encodeURIComponent(absoluteUrl)}`,
+      `&response_type=code`,
+      `&scope=${encodeURIComponent(scope)}`,
+      `&access_type=offline`,
+      `&prompt=consent`
+    ].join('');
+    window.location.href = authUrl;
   };
 
   return (


### PR DESCRIPTION
## 연관 이슈

close #163 

<br/>

## 개요

구글 로그인 구현

<br/>

## ✅ 작업 내용

- [x] 구글 로그인 구현 
- [x] 마이페이지 소셜 로그인 로고 표시
- [x] 불가능한 서비스 준비중 표시


<br/>

## 🖥 구현 결과


https://github.com/user-attachments/assets/be200afb-f5d4-449f-a341-c0b357ea0792


https://github.com/user-attachments/assets/798a0e96-7387-4228-ad59-6369b3f0fd7c



<br/>

### 리뷰 요구사항



<br/>

### 📝 기타 사항
`/login/auth `부분이 좀 수정이 되었어요!!
switch 문으로 각 type에 따라 다른 try catch 문을 실행하도록 했는데, 가독성 측면에서는 좋을 것 같아 이런 방식으로 구현했어요

const [oauthAccessToken, setOauthAccessToken] = useState('');

발급받은 oauth 토큰을 state로 저장해 백엔드 서버에 전송하는 방식입니다
(oauthtoken이 없다면 서버로 전송되지 않습니다)

저번에 리뷰해줬던 부분도 새롭게 반영했어요~~~

현재 네이버 로그인이 합쳐지진 않은 상태기 때문에 준비중도 급하게 추가했어요 
바로 서버에 반영되는 걸 미처 생각하고 있지 못했네요...
env는 노션에 적어둘게용
<br/>

<br/>
