### PR TITLE
[Test] 카카오 인앱 구분 테스트

### DIFF
--- a/src/app/test/page.tsx
+++ b/src/app/test/page.tsx
@@ -22,61 +22,69 @@ interface BeforeInstallPromptEvent extends Event {
 }
 
 const page = () => {
-  const [deferredPrompt, setDeferredPrompt] = useState(null);
-  const [isIOS, setIsIOS] = useState(false);
-  const [isAndroid, setIsAndroid] = useState(false);
-
+  const [deferredPrompt, setDeferredPrompt] =
+    useState<BeforeInstallPromptEvent | null>(null);
+  const [platform, setPlatform] = useState<'ios' | 'android' | 'other'>(
+    'other'
+  );
+  const [isKakaoInApp, setIsKakaoInApp] = useState(false);
   const [showModal, setShowModal] = useState(false);
 
   useEffect(() => {
     const userAgent = window.navigator.userAgent.toLowerCase();
-    const isIOSDevice = /iphone|ipad|ipod/.test(userAgent);
-    const isAndroidDevice = /android/.test(userAgent);
+    const isIOS = /iphone|ipad|ipod/.test(userAgent);
+    const isAndroid = /android/.test(userAgent);
+    const isKakao = /kakaotalk/i.test(userAgent);
 
-    setIsIOS(isIOSDevice);
-    setIsAndroid(isAndroidDevice);
+    setPlatform(isIOS ? 'ios' : isAndroid ? 'android' : 'other');
+    setIsKakaoInApp(isKakao);
 
-    // Android에서만 beforeinstallprompt 이벤트 처리
-    if (isAndroidDevice) {
-      const handler = (e: any) => {
-        console.log('🔥 beforeinstallprompt 발생');
-        e.preventDefault();
-        setDeferredPrompt(e);
-      };
+    if (isKakao) {
+      if (isAndroid) {
+        const currentUrl = window.location.href;
+        const intentUrl = `intent://${currentUrl.replace(
+          /^https?:\/\//,
+          ''
+        )}#Intent;scheme=https;package=com.android.chrome;end`;
+        window.location.href = intentUrl;
+      } else if (isIOS) {
+        alert(
+          '화면 우측 하단 공유하기 메뉴에서 "Safari로 열기"를 선택해주세요.'
+        );
+      }
+    } else {
+      if (isAndroid) {
+        const handler = (e: any) => {
+          e.preventDefault();
+          setDeferredPrompt(e);
+        };
+        window.addEventListener('beforeinstallprompt', handler);
+        return () => window.removeEventListener('beforeinstallprompt', handler);
+      }
 
-      window.addEventListener('beforeinstallprompt', handler);
-      return () => {
-        window.removeEventListener('beforeinstallprompt', handler);
-      };
+      // 외부 브라우저일 경우 진입 시 설치 모달 자동 오픈
+      setShowModal(true);
     }
   }, []);
 
-  const handleInstallClick = async () => {
-    if (isAndroid && deferredPrompt) {
+  const handleInstall = async () => {
+    if (platform === 'android' && deferredPrompt) {
       deferredPrompt.prompt();
       const { outcome } = await deferredPrompt.userChoice;
-      console.log('Android 사용자 선택:', outcome);
+      console.log('설치 결과:', outcome);
+      if (outcome === 'accepted') {
+        alert('설치가 완료되었습니다!');
+      } else {
+        alert('설치가 취소되었습니다.');
+      }
       setDeferredPrompt(null);
       setShowModal(false);
-    } else if (isIOS) {
-      // iOS는 안내만
-      alert(
-        'iPhone 사용자는 Safari에서 공유 버튼을 눌러 [홈 화면에 추가]를 선택해주세요!'
-      );
+    } else if (platform === 'ios') {
+      alert('하단 공유 버튼을 누르고 "홈 화면에 추가"를 선택해주세요.');
       setShowModal(false);
     } else {
-      alert('설치 기능이 현재 환경에서 지원되지 않습니다.');
+      alert('현재 환경에서는 설치가 지원되지 않습니다.');
       setShowModal(false);
-    }
-  };
-
-  const handleShowModal = () => {
-    if (isAndroid && deferredPrompt) {
-      setShowModal(true);
-    } else if (isIOS) {
-      setShowModal(true);
-    } else {
-      alert('브라우저가 아직 설치를 허용하지 않았습니다.');
     }
   };
 
@@ -86,19 +94,19 @@ const page = () => {
       <Button
         buttonType="primary"
         text="앱 설치하기"
-        onClick={handleShowModal}
+        onClick={() => setShowModal(true)}
       />
       {showModal && (
         <ConfirmModal
-          title="PWA 설치하기"
+          title="앱 설치하기"
           sub={
-            isIOS
-              ? 'Safari 공유 버튼을 눌러 [홈 화면에 추가]를 선택해주세요.'
-              : '홈 화면에 추가하시겠어요?'
+            platform === 'ios'
+              ? '홈 화면에 추가하시겠어요?'
+              : '앱을 설치하시겠어요?'
           }
-          confirmText={isIOS ? '알겠습니다' : '설치하기'}
+          confirmText="설치하기"
           cancelText="취소"
-          onConfirm={handleInstallClick}
+          onConfirm={handleInstall}
           onCancel={() => setShowModal(false)}
         />
       )}
@@ -114,7 +122,8 @@ const Container = styled.div`
   padding: 100px 30px;
   height: 100vh;
   flex-direction: column;
-  justify-content: space-between;
+  justify-content: center;
+  gap: 20px;
   background-image: url('/assets/login/login_bg.png');
   background-size: cover;
   background-position: center;
@@ -126,5 +135,6 @@ const Container = styled.div`
 
 const Title = styled.h1`
   color: ${theme.colors.white};
+  ${theme.fonts.title01}
   text-align: center;
 `;


### PR DESCRIPTION
## 연관 이슈

close #180
<br/>

## 개요

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요. -->
카카오 인앱에서는 외부 브라우저로 이동할 수 있도록 유도한다. 카카오 인앱이 아닐 경우 기존 테스트처럼 PWA 설치를 유도한다. 해당 내용이 서비스 내에서 기능할 수 있는지 확인한다.

<br/>

## ✅ 작업 내용

- [x] 카카오 인앱 구분
- [x] 외부 브라우저로 이동

<br/>

## 🖥 구현 결과

<!--  구현한 기능이 보이는 스크린샷을 업로드해주세요. -->

- iOS 외부 브라우저 (Safari)

https://github.com/user-attachments/assets/37c25b55-9e94-4477-987e-aace72404c51

<br/>

- iOS 카카오 인앱 브라우저

https://github.com/user-attachments/assets/714e04e9-b998-40d4-b00f-347ea9bf1940

- Android 카카오 인앱 브라우저 (자동으로 외부 브라우저 이동 시킴)

https://github.com/user-attachments/assets/87785f64-2dd5-4666-9117-99a303a16fb5

### 리뷰 요구사항

<!-- 리뷰 시에 유심히 봐주었으면 하는 부분이 있다면 설명해주세요. -->
따로 없습니다.

<br/>

### 📝 기타 사항

<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업 등을 적어주세요. -->
일단 제가 조사한 내용은 아래와 같아서 이 플로우로 만들었어요!
혹시 다른 가능한 방법도 있다면 언제든 말씀해주세요👍🏻🙆🏻‍♀️

### 동작 플로우

#### **1️⃣ 카카오 인앱 브라우저**

- 안드로이드 → `intent://` 사용해 크롬으로 자동 오픈
- iOS → Safari에서 열도록 안내 후 종료

#### **2️⃣ 외부 브라우저**

- 페이지 진입 시 `ConfirmModal` 자동 오픈:
    - **Android:** 설치 가능 시 설치 버튼 → 설치 시도
    - **iOS:** 설치 버튼 클릭 시 홈화면 추가 방법 안내

<br/>

***[참고]*** 카카오 인앱 브라우저에서 **자동으로 외부 브라우저(사파리/크롬)로 이동**시키는 것은 **불가능**

1. **iOS (Safari)**

- **iOS 보안 정책 상 인앱 브라우저 → Safari 강제 전환 불가능.**
- `intent://`, `app-ads.txt`, Universal Links 모두 **인앱 브라우저 내에서 강제 작동하지 않음**.
- 유일한 방법은 **유저가 직접 메뉴에서 “Safari로 열기”를 선택**하는 것뿐.

**2. Android (Chrome)**

- **`intent://` 스킴을 사용하여 크롬으로 유도 가능하지만,**
- 인앱 브라우저(카카오톡)에서 `intent://` 호출 시
    - 일부 기기/버전에서 경고 팝업 후 열림
    - 일부 기기/버전에서 동작하지 않음
- 따라서 **완전한 강제 전환은 불가능하며, 어느 정도는 유저가 허용을 선택해야 작동**합니다.
<br/>

<br/>
